### PR TITLE
Mark registry

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -16,9 +16,9 @@
 - A registry can now carry metadata just like a provider.
 - A registry now has an attribute
   :attr:`skosprovider.registry.Registry.instance_scope` that indicates how the
-  registry is being run. This can help providers determine if they're
-  compatible with a registry run this was. Especially important for
-  SQLAlchemyProvider run in a web application.
+  registry is managed in the application process. This can help providers 
+  determine if they're compatible with a particular registry. Especially 
+  important for SQLAlchemyProvider run in a web application.
 - Fix a bug that made it impossible for a
   :class:`~skosprovider.providers.SimpleCsvProvider` to read sources. (#36)
 - Drop support for Python 3.3.

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -14,6 +14,11 @@
   conceptschemes to :meth:`skosprovider.providers.VocabularyProvider.find`.
   (#58)
 - A registry can now carry metadata just like a provider.
+- A registry now has an attribute
+  :attr:`skosprovider.registry.Registry.instance_scope` that indicates how the
+  registry is being run. This can help providers determine if they're
+  compatible with a registry run this was. Especially important for
+  SQLAlchemyProvider run in a web application.
 - Fix a bug that made it impossible for a
   :class:`~skosprovider.providers.SimpleCsvProvider` to read sources. (#36)
 - Drop support for Python 3.3.

--- a/skosprovider/registry.py
+++ b/skosprovider/registry.py
@@ -56,7 +56,7 @@ class Registry:
           other session handling code generally require this.
     '''
 
-    def __init__(self, instance_scope = 'single', metadata={}):
+    def __init__(self, instance_scope='single', metadata={}):
         '''
         :param str instance_scope: Indicates how the registry was instantiated.
             Possible values: single, threaded_global, threaded_thread.

--- a/skosprovider/registry.py
+++ b/skosprovider/registry.py
@@ -35,8 +35,31 @@ class Registry:
     Dictionary containing metadata about this registry.
     '''
 
-    def __init__(self, metadata={}):
+    instance_scope = 'single'
+    '''
+    Indicates how the registry is being used. Options:
+        - single: The registry is part of a script or a single process. It can
+          be assumed to be operational for the entire duration of the process
+          and there are no threads involved.
+        - threaded_global: The registry is part of a program that uses threads,
+          such as a typical web application. It's attached to the global process
+          and duplicated to threads, making it not thread safe. Proceed carefully
+          with certain providers. Should generally only be used with
+          applications that only use read-only providers that load all data in
+          memory at startup and use no database connections or other kinds of
+          sessions.
+        - threaded_thread: The registry is part of a program that uses threads,
+          such as a typical web application. It's attached to a thread, such as
+          a web request. The registry is instantiated for this thread/request and
+          dies with this thread/request. This is needed for providers such
+          as the SQLAlchemyProvider. Providers that use database connections or
+          other session handling code generally require this.
+    '''
+
+    def __init__(self, instance_scope = 'single', metadata={}):
         '''
+        :param str instance_scope: Indicates how the registry was instantiated.
+            Possible values: single, threaded_global, threaded_thread.
         :param dict metadata: Metadata essential to this registry. Possible
             metadata:
 
@@ -52,6 +75,9 @@ class Registry:
         self.providers = {}
         self.concept_scheme_uri_map = {}
         self.metadata = metadata
+        if instance_scope not in ['single', 'threaded_global', 'threaded_thread']:
+            raise ValueError('Invalid instance_scope.')
+        self.instance_scope = instance_scope
 
     def get_metadata(self):
         '''Get some metadata on the registry it represents.

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -17,6 +17,8 @@ from skosprovider.registry import (
     RegistryException
 )
 
+import pytest
+
 
 class RegistryTests(unittest.TestCase):
     def setUp(self):
@@ -33,9 +35,17 @@ class RegistryTests(unittest.TestCase):
         self.assertIsInstance(self.reg.get_metadata(), dict)
 
     def test_passed_metadata_is_dict(self):
-        self.reg = Registry({'catalog': {'uri': 'http://my.data.org'}})
+        self.reg = Registry(metadata={'catalog': {'uri': 'http://my.data.org'}})
         self.assertIn('catalog', self.reg.get_metadata())
         self.assertIn('uri', self.reg.get_metadata().get('catalog'))
+
+    def test_set_instance_scope(self):
+        self.reg = Registry(instance_scope='threaded_global')
+        assert self.reg.instance_scope == 'threaded_global'
+
+    def test_set_invalid_instance_scope(self):
+        with pytest.raises(ValueError):
+            Registry(instance_scope='bad_scope')
 
     def test_empty_register_provider(self):
         self.reg.register_provider(self.prov)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -36,8 +36,8 @@ class RegistryTests(unittest.TestCase):
 
     def test_passed_metadata_is_dict(self):
         self.reg = Registry(metadata={'catalog': {'uri': 'http://my.data.org'}})
-        self.assertIn('catalog', self.reg.get_metadata())
-        self.assertIn('uri', self.reg.get_metadata().get('catalog'))
+        assert 'catalog' in self.reg.get_metadata()
+        assert 'uri' in self.reg.get_metadata().get('catalog')
 
     def test_set_instance_scope(self):
         self.reg = Registry(instance_scope='threaded_global')


### PR DESCRIPTION
Add a flag to indicate how a registry was instantiated. This allows providers to determine if they're a good match for a certain registry.