### PR TITLE
Evaluate how to decide what language to return of a given thing

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -32,8 +32,9 @@ view of the :mod:`SKOS data model <skosprovider.skos>`.
 Because of this, the only part where the different providers are different is
 when instantiating the provider, since they need to be configured for their 
 data source. Eg., the :class:`skosprovider.providers.DictionaryProvider` is
-a very simple provider that requires a list of dictionaries to operate on.
-Apart from this one very specific data element, there are a few configuration
+a very simple provider that requires a list of concept and collection
+dictionaries as ``concepts_and_collections``. Apart from this one very
+specific data element, there are a few configuration
 :meth:`parameters <skosprovider.providers.VocabularyProvider.__init__>` that 
 are passed to every existing provider. Every provider requires that a 
 parameter `metadata` is passed to it. This is a dictionary that has one 
@@ -50,6 +51,10 @@ you do not pass in a uri generator, the provider will set one up for you.
 Finally, you can also pass in a :class:`skosprovider.skos.ConceptScheme`. This
 is the concept scheme the providers represents. Again, if you do no pass in a
 concept scheme, the provider will create a default scheme.
+
+For in-memory providers, the second constructor argument is named
+``concepts_and_collections`` to make it explicit that the list may contain both
+concepts and collections.
 
 .. code-block:: python
 

--- a/skosprovider/providers.py
+++ b/skosprovider/providers.py
@@ -459,6 +459,11 @@ class MemoryProvider(VocabularyProvider):
             :class:`skosprovider.skos.Collection` instances.
         :param Boolean case_insensitive: Should searching for labels be done
             case-insensitive?
+
+        .. versionchanged:: 2.0.0
+            The second positional argument was renamed from ``list`` to
+            ``concepts`` to avoid shadowing the builtin. Callers that passed
+            it as a keyword argument must be updated.
         """
         super().__init__(metadata, **kwargs)
         if "allowed_instance_scopes" not in kwargs:

--- a/skosprovider/providers.py
+++ b/skosprovider/providers.py
@@ -93,17 +93,21 @@ class VocabularyProvider:
         self.allowed_instance_scopes = kwargs.get(
             "allowed_instance_scopes", ["single", "threaded_thread"]
         )
+        default_language = self.metadata.get("default_language")
+        if default_language is not None:
+            self.concept_scheme.default_language = default_language
 
     def _get_language(self, **kwargs):
         """Determine what language to render labels in.
 
         Will first check if there's a language keyword specified in **kwargs.
         If not, will check the default language of the provider. If there's no
-        default language, will fall back to 'en'.
+        default language, returns `None`, which lets the label lookup fall
+        back to any available label.
 
-        :rtype: str
+        :rtype: str or None
         """
-        return kwargs.get("language", self.metadata.get("default_language", "en"))
+        return kwargs.get("language", self.metadata.get("default_language"))
 
     def _get_sort(self, **kwargs):
         """Determine on what attribute to sort.
@@ -120,7 +124,7 @@ class VocabularyProvider:
         """
         return kwargs.get("sort_order", "asc")
 
-    def _sort(self, concepts, sort=None, language="any", reverse=False):
+    def _sort(self, concepts, sort=None, language=None, reverse=False):
         """
         Returns a sorted version of a list of concepts. Will leave the original
         list unsorted.
@@ -448,10 +452,10 @@ class MemoryProvider(VocabularyProvider):
     be triggered by providing a `case_insensitive` keyword to the constructor.
     """
 
-    def __init__(self, metadata, list, **kwargs):
+    def __init__(self, metadata, concepts, **kwargs):
         """
         :param dict metadata: A dictionary with keywords like language.
-        :param list list: A list of :class:`skosprovider.skos.Concept` and
+        :param list concepts: A list of :class:`skosprovider.skos.Concept` and
             :class:`skosprovider.skos.Collection` instances.
         :param Boolean case_insensitive: Should searching for labels be done
             case-insensitive?
@@ -463,9 +467,17 @@ class MemoryProvider(VocabularyProvider):
                 "threaded_thread",
                 "threaded_global",
             ]
-        self.list = list
         if "case_insensitive" in kwargs:
             self.case_insensitive = kwargs["case_insensitive"]
+        self._set_concepts(concepts)
+
+    def _set_concepts(self, concepts):
+        """Register the list of concepts/collections with this provider."""
+        default_language = self.metadata.get("default_language")
+        if default_language is not None:
+            for item in concepts:
+                item.default_language = default_language
+        self.list = concepts
 
     def get_by_id(self, id):
         id = str(id)
@@ -688,9 +700,12 @@ class DictionaryProvider(MemoryProvider):
     the concepts.
     """
 
-    def __init__(self, metadata, list, **kwargs):
+    def __init__(self, metadata, concepts, **kwargs):
+        # ``_from_dict`` needs ``self.uri_generator`` / ``self.concept_scheme``,
+        # which are only populated once ``super().__init__`` has run. So we
+        # initialise with an empty list, then register the built concepts.
         super().__init__(metadata, [], **kwargs)
-        self.list = [self._from_dict(c) for c in list]
+        self._set_concepts([self._from_dict(c) for c in concepts])
 
     def _from_dict(self, data):
         if "type" in data and data["type"] == "collection":
@@ -748,7 +763,7 @@ class SimpleCsvProvider(MemoryProvider):
         :param reader: A csv reader.
         """
         super().__init__(metadata, [], **kwargs)
-        self.list = [self._from_row(row) for row in reader]
+        self._set_concepts([self._from_row(row) for row in reader])
 
     def _from_row(self, row):
         id = row[0]

--- a/skosprovider/providers.py
+++ b/skosprovider/providers.py
@@ -452,10 +452,11 @@ class MemoryProvider(VocabularyProvider):
     be triggered by providing a `case_insensitive` keyword to the constructor.
     """
 
-    def __init__(self, metadata, concepts, **kwargs):
+    def __init__(self, metadata, concepts_and_collections, **kwargs):
         """
         :param dict metadata: A dictionary with keywords like language.
-        :param list concepts: A list of :class:`skosprovider.skos.Concept` and
+        :param list concepts_and_collections: A list of
+            :class:`skosprovider.skos.Concept` and
             :class:`skosprovider.skos.Collection` instances.
         :param Boolean case_insensitive: Should searching for labels be done
             case-insensitive?
@@ -464,6 +465,12 @@ class MemoryProvider(VocabularyProvider):
             The second positional argument was renamed from ``list`` to
             ``concepts`` to avoid shadowing the builtin. Callers that passed
             it as a keyword argument must be updated.
+
+        .. versionchanged:: 4.1.0
+            The second positional argument was renamed from ``concepts`` to
+            ``concepts_and_collections`` to better reflect that this list can
+            contain both concepts and collections. Callers that passed it as a
+            keyword argument must be updated.
         """
         super().__init__(metadata, **kwargs)
         if "allowed_instance_scopes" not in kwargs:
@@ -474,7 +481,7 @@ class MemoryProvider(VocabularyProvider):
             ]
         if "case_insensitive" in kwargs:
             self.case_insensitive = kwargs["case_insensitive"]
-        self._set_concepts(concepts)
+        self._set_concepts(concepts_and_collections)
 
     def _set_concepts(self, concepts):
         """Register the list of concepts/collections with this provider."""
@@ -705,12 +712,23 @@ class DictionaryProvider(MemoryProvider):
     the concepts.
     """
 
-    def __init__(self, metadata, concepts, **kwargs):
+    def __init__(self, metadata, concepts_and_collections, **kwargs):
+        """
+        :param dict metadata: A dictionary with keywords like language.
+        :param list concepts_and_collections: A list of dicts representing
+            concepts and collections.
+
+        .. versionchanged:: 4.1.0
+            The second positional argument was renamed from ``concepts`` to
+            ``concepts_and_collections`` to better reflect that this list can
+            contain both concepts and collections. Callers that passed it as a
+            keyword argument must be updated.
+        """
         # ``_from_dict`` needs ``self.uri_generator`` / ``self.concept_scheme``,
         # which are only populated once ``super().__init__`` has run. So we
         # initialise with an empty list, then register the built concepts.
         super().__init__(metadata, [], **kwargs)
-        self._set_concepts([self._from_dict(c) for c in concepts])
+        self._set_concepts([self._from_dict(c) for c in concepts_and_collections])
 
     def _from_dict(self, data):
         if "type" in data and data["type"] == "collection":

--- a/skosprovider/skos.py
+++ b/skosprovider/skos.py
@@ -409,7 +409,7 @@ class Concept:
 
         This uses the :func:`label` function to determine which label to return.
 
-        :param language: The preferred language to receive the label in.
+        :param string language: The preferred language to receive the label in.
             This should be a valid IANA language tag or a list of language tags.
             If not specified or `None`, the :attr:`default_language` will be used,
             falling back to any available label.
@@ -422,7 +422,7 @@ class Concept:
         Provide a single sortkey for this collection.
 
         :param string key: Either `id`, `uri`, `label` or `sortlabel`.
-        :param language: The preferred language to receive the label in
+        :param string language: The preferred language to receive the label in
             if key is `label` or `sortlabel`. This should be a valid IANA language tag.
             If not specified or `None`, the :attr:`default_language` will be used.
         :rtype: :class:`str`
@@ -518,7 +518,7 @@ class Collection:
 
         This uses the :func:`label` function to determine which label to return.
 
-        :param language: The preferred language to receive the label in.
+        :param string language: The preferred language to receive the label in.
             This should be a valid IANA language tag. If not specified or `None`,
             the :attr:`default_language` will be used, falling back to any
             available label.
@@ -531,7 +531,7 @@ class Collection:
         Provide a single sortkey for this collection.
 
         :param string key: Either `id`, `uri`, `label` or `sortlabel`.
-        :param language: The preferred language to receive the label in
+        :param string language: The preferred language to receive the label in
             if key is `label` or `sortlabel`. This should be a valid IANA language tag.
             If not specified or `None`, the :attr:`default_language` will be used.
         :rtype: :class:`str`
@@ -553,10 +553,13 @@ class Collection:
 
 
 def _resolve_language(language, default_language):
-    """Combine an explicit language with the configured default."""
+    """Combine an explicit language with the configured default.
+
+    Always returns a list so callers have a single return type to handle.
+    """
     if language is None:
-        return default_language
-    if isinstance(language, str):
+        language = []
+    elif isinstance(language, str):
         language = [language]
     else:
         language = list(language)

--- a/skosprovider/skos.py
+++ b/skosprovider/skos.py
@@ -260,16 +260,6 @@ class ConceptScheme:
     There's no guarantuee that labels or notes in other languages do not exist.
     """
 
-    default_language = None
-    """
-    The default language to use when requesting labels without specifying
-    a language. `None` by default, meaning no preferred language -- any
-    available label will be returned. Can be set by a provider to its own
-    default language.
-
-    .. versionadded:: 2.0.0
-    """
-
     def __init__(
         self,
         uri,
@@ -321,16 +311,7 @@ class ConceptScheme:
         return sortlabel.label.lower() if sortlabel else ""
 
     def _resolve_language(self, language):
-        """Combine an explicit language with the configured default."""
-        if language is None:
-            return self.default_language
-        if isinstance(language, str):
-            language = [language]
-        else:
-            language = list(language)
-        if self.default_language and self.default_language not in language:
-            language.append(self.default_language)
-        return language
+        return _resolve_language(language, self.default_language)
 
     def __repr__(self):
         return f"ConceptScheme('{self.uri}')"
@@ -397,16 +378,6 @@ class Concept:
 
     This dictionary contains a key for each type of Match (close, exact,
     related, broad, narrow). Attached to each key is a list of URI's.
-    """
-
-    default_language = None
-    """
-    The default language to use when requesting labels without specifying
-    a language. `None` by default, meaning no preferred language -- any
-    available label will be returned. Can be set by a provider to its own
-    default language.
-
-    .. versionadded:: 2.0.0
     """
 
     def __init__(
@@ -476,16 +447,7 @@ class Concept:
         return sortlabel.label.lower() if sortlabel else ""
 
     def _resolve_language(self, language):
-        """Combine an explicit language with the configured default."""
-        if language is None:
-            return self.default_language
-        if isinstance(language, str):
-            language = [language]
-        else:
-            language = list(language)
-        if self.default_language and self.default_language not in language:
-            language.append(self.default_language)
-        return language
+        return _resolve_language(language, self.default_language)
 
     def __repr__(self):
         return f"Concept('{self.id}')"
@@ -532,16 +494,6 @@ class Collection:
     infer_concept_relations = True
     """Should member concepts of this collection be seen as narrower concept of
     a superordinate of the collection?"""
-
-    default_language = None
-    """
-    The default language to use when requesting labels without specifying
-    a language. `None` by default, meaning no preferred language -- any
-    available label will be returned. Can be set by a provider to its own
-    default language.
-
-    .. versionadded:: 2.0.0
-    """
 
     def __init__(
         self,
@@ -604,19 +556,23 @@ class Collection:
         return sortlabel.label.lower() if sortlabel else ""
 
     def _resolve_language(self, language):
-        """Combine an explicit language with the configured default."""
-        if language is None:
-            return self.default_language
-        if isinstance(language, str):
-            language = [language]
-        else:
-            language = list(language)
-        if self.default_language and self.default_language not in language:
-            language.append(self.default_language)
-        return language
+        return _resolve_language(language, self.default_language)
 
     def __repr__(self):
         return f"Collection('{self.id}')"
+
+
+def _resolve_language(language, default_language):
+    """Combine an explicit language with the configured default."""
+    if language is None:
+        return default_language
+    if isinstance(language, str):
+        language = [language]
+    else:
+        language = list(language)
+    if default_language and default_language not in language:
+        language.append(default_language)
+    return language
 
 
 def label(labels=None, language=None, sortLabel=False):
@@ -645,13 +601,13 @@ def label(labels=None, language=None, sortLabel=False):
       returning any available label, regardless of language. If the list of
       labels is empty (or only contains hidden labels), `None` is returned.
 
-    ..versionchanged:: 2.0.0
+    .. versionchanged:: 2.0.0
         The magic value `"any"` is no longer supported -- pass `None` instead.
         `None` no longer means "labels explicitly tagged as `und`"; use the
         tag `"und"` for that. Language matching now walks down the subtag
         chain rather than collapsing straight to the primary language.
 
-    ..versionchanged:: 1.1
+    .. versionchanged:: 1.1
         It is now possible to pass a list of languages.
 
     :param labels: A list of :class:`Label` (or dicts convertible to one).
@@ -757,7 +713,7 @@ def filter_labels_by_language(labels, language):
     :mod:`language_tags`). To walk the subtag chain, iterate with
     :func:`_language_fallback_chain` yourself.
 
-    ..versionchanged:: 2.0.0
+    .. versionchanged:: 2.0.0
         The `broader` parameter and the magic `"any"` value have been removed.
 
     :param list labels: A list of :class:`Label`.

--- a/skosprovider/skos.py
+++ b/skosprovider/skos.py
@@ -260,7 +260,25 @@ class ConceptScheme:
     There's no guarantuee that labels or notes in other languages do not exist.
     """
 
-    def __init__(self, uri, labels=None, notes=None, sources=None, languages=None):
+    default_language = None
+    """
+    The default language to use when requesting labels without specifying
+    a language. `None` by default, meaning no preferred language -- any
+    available label will be returned. Can be set by a provider to its own
+    default language.
+
+    .. versionadded:: 2.0.0
+    """
+
+    def __init__(
+        self,
+        uri,
+        labels=None,
+        notes=None,
+        sources=None,
+        languages=None,
+        default_language=None,
+    ):
         if not is_uri(uri):
             raise ValueError(f"{uri} is not a valid URI.")
         self.uri = uri
@@ -268,8 +286,9 @@ class ConceptScheme:
         self.notes = [dict_to_note(note) for note in notes] if notes else []
         self.sources = [dict_to_source(source) for source in sources] if sources else []
         self.languages = languages or []
+        self.default_language = default_language
 
-    def label(self, language="any"):
+    def label(self, language=None):
         """
         Provide a single label for this conceptscheme.
 
@@ -277,25 +296,41 @@ class ConceptScheme:
         return.
 
         :param string language: The preferred language to receive the label in.
-            This should be a valid IANA language tag.
+            This should be a valid IANA language tag. If not specified or `None`,
+            the :attr:`default_language` will be used, falling back to any
+            available label.
         :rtype: :class:`skosprovider.skos.Label` or None if no labels were found.
         """
-        return label(self.labels, language)
+        return label(self.labels, self._resolve_language(language))
 
-    def _sortkey(self, key="uri", language="any"):
+    def _sortkey(self, key="uri", language=None):
         """
         Provide a single sortkey for this conceptscheme.
 
         :param string key: Either `uri`, `label` or `sortlabel`.
         :param string language: The preferred language to receive the label in
             if key is `label` or `sortlabel`. This should be a valid IANA language tag.
+            If not specified or `None`, the :attr:`default_language` will be used.
         :rtype: :class:`str`
         """
         if key == "uri":
             return self.uri
+        sortlabel = label(
+            self.labels, self._resolve_language(language), key == "sortlabel"
+        )
+        return sortlabel.label.lower() if sortlabel else ""
+
+    def _resolve_language(self, language):
+        """Combine an explicit language with the configured default."""
+        if language is None:
+            return self.default_language
+        if isinstance(language, str):
+            language = [language]
         else:
-            sortlabel = label(self.labels, language, key == "sortlabel")
-            return sortlabel.label.lower() if sortlabel else ""
+            language = list(language)
+        if self.default_language and self.default_language not in language:
+            language.append(self.default_language)
+        return language
 
     def __repr__(self):
         return f"ConceptScheme('{self.uri}')"
@@ -364,6 +399,16 @@ class Concept:
     related, broad, narrow). Attached to each key is a list of URI's.
     """
 
+    default_language = None
+    """
+    The default language to use when requesting labels without specifying
+    a language. `None` by default, meaning no preferred language -- any
+    available label will be returned. Can be set by a provider to its own
+    default language.
+
+    .. versionadded:: 2.0.0
+    """
+
     def __init__(
         self,
         id,
@@ -378,6 +423,7 @@ class Concept:
         member_of=None,
         subordinate_arrays=None,
         matches=None,
+        default_language=None,
     ):
         self.id = id
         self.uri = uri
@@ -394,35 +440,52 @@ class Concept:
         self.matches = {key: [] for key in self.matchtypes}
         if matches:
             self.matches.update(matches)
+        self.default_language = default_language
 
-    def label(self, language="any"):
+    def label(self, language=None):
         """
         Provide a single label for this concept.
 
         This uses the :func:`label` function to determine which label to return.
 
-        :param string language: The preferred language to receive the label in.
+        :param language: The preferred language to receive the label in.
             This should be a valid IANA language tag or a list of language tags.
+            If not specified or `None`, the :attr:`default_language` will be used,
+            falling back to any available label.
         :rtype: :class:`skosprovider.skos.Label` or None if no labels were found.
         """
-        return label(self.labels, language)
+        return label(self.labels, self._resolve_language(language))
 
-    def _sortkey(self, key="id", language="any"):
+    def _sortkey(self, key="id", language=None):
         """
         Provide a single sortkey for this collection.
 
         :param string key: Either `id`, `uri`, `label` or `sortlabel`.
-        :param string language: The preferred language to receive the label in
+        :param language: The preferred language to receive the label in
             if key is `label` or `sortlabel`. This should be a valid IANA language tag.
+            If not specified or `None`, the :attr:`default_language` will be used.
         :rtype: :class:`str`
         """
         if key == "id":
             return str(self.id)
         elif key == "uri":
             return self.uri if self.uri else ""
+        sortlabel = label(
+            self.labels, self._resolve_language(language), key == "sortlabel"
+        )
+        return sortlabel.label.lower() if sortlabel else ""
+
+    def _resolve_language(self, language):
+        """Combine an explicit language with the configured default."""
+        if language is None:
+            return self.default_language
+        if isinstance(language, str):
+            language = [language]
         else:
-            sortlabel = label(self.labels, language, key == "sortlabel")
-            return sortlabel.label.lower() if sortlabel else ""
+            language = list(language)
+        if self.default_language and self.default_language not in language:
+            language.append(self.default_language)
+        return language
 
     def __repr__(self):
         return f"Concept('{self.id}')"
@@ -470,6 +533,16 @@ class Collection:
     """Should member concepts of this collection be seen as narrower concept of
     a superordinate of the collection?"""
 
+    default_language = None
+    """
+    The default language to use when requesting labels without specifying
+    a language. `None` by default, meaning no preferred language -- any
+    available label will be returned. Can be set by a provider to its own
+    default language.
+
+    .. versionadded:: 2.0.0
+    """
+
     def __init__(
         self,
         id,
@@ -482,6 +555,7 @@ class Collection:
         member_of=None,
         superordinates=None,
         infer_concept_relations=True,
+        default_language=None,
     ):
         self.id = id
         self.uri = uri
@@ -494,41 +568,58 @@ class Collection:
         self.member_of = member_of or []
         self.superordinates = superordinates or []
         self.infer_concept_relations = infer_concept_relations
+        self.default_language = default_language
 
-    def label(self, language="any"):
+    def label(self, language=None):
         """
         Provide a single label for this collection.
 
         This uses the :func:`label` function to determine which label to return.
 
-        :param string language: The preferred language to receive the label in.
-            This should be a valid IANA language tag.
+        :param language: The preferred language to receive the label in.
+            This should be a valid IANA language tag. If not specified or `None`,
+            the :attr:`default_language` will be used, falling back to any
+            available label.
         :rtype: :class:`skosprovider.skos.Label` or None if no labels were found.
         """
-        return label(self.labels, language, False)
+        return label(self.labels, self._resolve_language(language), False)
 
-    def _sortkey(self, key="id", language="any"):
+    def _sortkey(self, key="id", language=None):
         """
         Provide a single sortkey for this collection.
 
         :param string key: Either `id`, `uri`, `label` or `sortlabel`.
-        :param string language: The preferred language to receive the label in
+        :param language: The preferred language to receive the label in
             if key is `label` or `sortlabel`. This should be a valid IANA language tag.
+            If not specified or `None`, the :attr:`default_language` will be used.
         :rtype: :class:`str`
         """
         if key == "id":
             return str(self.id)
         elif key == "uri":
             return self.uri if self.uri else ""
+        sortlabel = label(
+            self.labels, self._resolve_language(language), key == "sortlabel"
+        )
+        return sortlabel.label.lower() if sortlabel else ""
+
+    def _resolve_language(self, language):
+        """Combine an explicit language with the configured default."""
+        if language is None:
+            return self.default_language
+        if isinstance(language, str):
+            language = [language]
         else:
-            sortlabel = label(self.labels, language, key == "sortlabel")
-            return sortlabel.label.lower() if sortlabel else ""
+            language = list(language)
+        if self.default_language and self.default_language not in language:
+            language.append(self.default_language)
+        return language
 
     def __repr__(self):
         return f"Collection('{self.id}')"
 
 
-def label(labels=None, language="any", sortLabel=False):
+def label(labels=None, language=None, sortLabel=False):
     """
     Provide a label for a list of labels.
 
@@ -536,41 +627,36 @@ def label(labels=None, language="any", sortLabel=False):
     :class:`Label`, or dicts with at least the key `label` in them. These will
     be passed to the :func:`dict_to_label` function.
 
-    This method tries to find a label by looking if there's
-    a pref label for the specified language. If there's no pref label,
-    it looks for an alt label. It disregards hidden labels.
+    Within each candidate language the function prefers a `prefLabel` over an
+    `altLabel` (and a `sortLabel` over both when `sortLabel=True`). Hidden
+    labels are never considered.
 
-    While matching languages, preference will be given to exact matches. But,
-    if no exact match is present, an inexact match will be attempted. This might
-    be because a label in language `nl-BE` is being requested, but only `nl` or
-    even `nl-NL` is present. Similarly, when requesting `nl`, a label with
-    language `nl-NL` or even `nl-Latn-NL` will also be considered,
-    providing no label is present that has an exact match with the
-    requested language.
+    Language resolution:
 
-    It's possible to pass multiple languages as a list. In this case, the method
-    will try handling each language in turn. Please be aware that this includes
-    handling variations. When assing `nl-BE, nl, nl-NL`, the second and third
-    languages will never be handled since handling `nl-BE` includes looking for
-    other related languages such as `nl-NL` and `nl`.
+    - Passing `None` (or omitting the argument) means "no preference" --
+      any available label is returned.
+    - Passing a specific IANA language tag such as `en-GB` will first look for
+      an exact match on that tag, then progressively drop subtags
+      (e.g. `nl-BE-Latn` -> `nl-BE` -> `nl`). The literal tag `und` behaves
+      like any other tag and only matches labels explicitly tagged as `und`.
+    - Passing a list of tags tries each in turn, applying the same subtag
+      fallback to each.
+    - If no language-specific label can be found, the function falls back to
+      returning any available label, regardless of language. If the list of
+      labels is empty (or only contains hidden labels), `None` is returned.
 
-    If language 'any' was specified, all labels will be considered,
-    regardless of language.
-
-    To find a label without a specified language, pass `None` as language.
-
-    If a language or None was specified, and no label could be found, this
-    method will automatically try to find a label in some other language.
-
-    Finally, if no label could be found, None is returned.
+    ..versionchanged:: 2.0.0
+        The magic value `"any"` is no longer supported -- pass `None` instead.
+        `None` no longer means "labels explicitly tagged as `und`"; use the
+        tag `"und"` for that. Language matching now walks down the subtag
+        chain rather than collapsing straight to the primary language.
 
     ..versionchanged:: 1.1
         It is now possible to pass a list of languages.
 
-    :param any language: The preferred language to receive the label in. This
-        should be a valid IANA language tag or list of language tags. If you
-        pass a list, the order of the languages in the list will be taken into
-        account when trying to determine a label.
+    :param labels: A list of :class:`Label` (or dicts convertible to one).
+    :param language: The preferred language to receive the label in. This
+        should be a valid IANA language tag, a list of such tags, or `None`.
     :param boolean sortLabel: Should sortLabels be considered or not? If True,
         sortLabels will be preferred over prefLabels. Bear in mind that these
         are still language dependent. So, it's possible to have a different
@@ -579,71 +665,106 @@ def label(labels=None, language="any", sortLabel=False):
     """
     if not labels:
         return None
+    labels = [dict_to_label(label) for label in labels]
+
+    if language is None:
+        return _pick_best_label(labels, sortLabel)
+
     if isinstance(language, str):
         language = [language]
-    if isinstance(language, list):
-        language = [lang for lang in language if tags.tag(lang).language]
-    if not language:
-        language = ["und"]
-    labels = [dict_to_label(label) for label in labels]
-    return_label = False
+    language = [lang for lang in language if lang and tags.tag(lang).language]
+
+    type_order = ("prefLabel", "altLabel")
+    if sortLabel:
+        type_order = ("sortLabel",) + type_order
+
     for lang in language:
-        if sortLabel:
-            return_label = find_best_label_for_type(labels, lang, "sortLabel")
-        if not return_label:
-            return_label = find_best_label_for_type(labels, lang, "prefLabel")
-        if not return_label:
-            return_label = find_best_label_for_type(labels, lang, "altLabel")
-        if return_label:
-            return return_label
-    return label(labels, "any", sortLabel) if "any" not in language else None
+        for labeltype in type_order:
+            found = find_best_label_for_type(labels, lang, labeltype)
+            if found:
+                return found
+
+    return _pick_best_label(labels, sortLabel)
+
+
+def _language_fallback_chain(language):
+    """Yield progressively less specific forms of an IANA language tag.
+
+    For `nl-BE-Latn` this yields `nl-BE-Latn`, `nl-BE`, `nl`.
+    """
+    parts = language.split("-")
+    while parts:
+        yield "-".join(parts)
+        parts.pop()
+
+
+def _primary_language(language):
+    """Return the canonical primary subtag of an IANA language tag, or None."""
+    subtag = tags.tag(language).language
+    return subtag.format if subtag else None
+
+
+def _pick_best_label(labels, sortLabel):
+    """Pick the best-typed label from a list, disregarding language."""
+    if not labels:
+        return None
+    type_order = ("prefLabel", "altLabel")
+    if sortLabel:
+        type_order = ("sortLabel",) + type_order
+    for ltype in type_order:
+        for lbl in labels:
+            if lbl.type == ltype:
+                return lbl
+    return None
 
 
 def find_best_label_for_type(labels, language, labeltype):
     """
-    Find the best label for a certain labeltype.
+    Find the best label of a specific type in a given language.
+
+    First tries an exact match on the language tag, then walks down the
+    subtag chain (e.g. `nl-BE-Latn` -> `nl-BE` -> `nl`). If still nothing
+    matches, falls back to any label that shares the same primary language
+    subtag (so `en-GB` will also match `en-US` once the more specific tries
+    are exhausted). Returns `False` if nothing matches.
 
     :param list labels: A list of :class:`Label`.
     :param str language: An IANA language string, eg. `nl` or `nl-BE`.
     :param str labeltype: Type of label to look for, eg. `prefLabel`.
     """
-    typelabels = [label for label in labels if label.type == labeltype]
+    typelabels = [lbl for lbl in labels if lbl.type == labeltype]
     if not typelabels:
         return False
-    if language == "any":
-        return typelabels[0]
-    exact = filter_labels_by_language(typelabels, language)
-    if exact:
-        return exact[0]
-    inexact = filter_labels_by_language(typelabels, language, True)
-    if inexact:
-        return inexact[0]
+    for candidate in _language_fallback_chain(language):
+        matches = filter_labels_by_language(typelabels, candidate)
+        if matches:
+            return matches[0]
+    primary = _primary_language(language)
+    if primary:
+        family = [
+            lbl for lbl in typelabels if _primary_language(lbl.language) == primary
+        ]
+        if family:
+            return family[0]
     return False
 
 
-def filter_labels_by_language(labels, language, broader=False):
+def filter_labels_by_language(labels, language):
     """
     Filter a list of labels, leaving only labels of a certain language.
 
+    Matches the IANA language tag exactly (canonicalised via
+    :mod:`language_tags`). To walk the subtag chain, iterate with
+    :func:`_language_fallback_chain` yourself.
+
+    ..versionchanged:: 2.0.0
+        The `broader` parameter and the magic `"any"` value have been removed.
+
     :param list labels: A list of :class:`Label`.
     :param str language: An IANA language string, eg. `nl` or `nl-BE`.
-    :param boolean broader: When true, will also match `nl-BE` when filtering
-        on `nl`. When false, only exact matches are considered.
     """
-    if language == "any":
-        return labels
-    if broader:
-        language = tags.tag(language).language.format
-        return [
-            label
-            for label in labels
-            if tags.tag(label.language).language.format == language
-        ]
-    else:
-        language = tags.tag(language).format
-        return [
-            label for label in labels if tags.tag(label.language).format == language
-        ]
+    target = tags.tag(language).format
+    return [lbl for lbl in labels if tags.tag(lbl.language).format == target]
 
 
 def dict_to_label(dict):

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -328,6 +328,25 @@ class TestTreesDictionaryProvider:
         assert isinstance(lariks.concept_scheme, ConceptScheme)
         assert "http://id.trees.org" == lariks.concept_scheme.uri
 
+    def test_concept_has_default_language(self):
+        lariks = trees.get_by_id(1)
+        assert lariks.default_language == "nl"
+
+    def test_concept_label_uses_default_language(self):
+        lariks = trees.get_by_id(1)
+        assert lariks.label().label == "De Lariks"
+
+    def test_collection_has_default_language(self):
+        coll = trees.get_by_id(3)
+        assert coll.default_language == "nl"
+
+    def test_collection_label_uses_default_language(self):
+        coll = trees.get_by_id(3)
+        assert coll.label().label == "Bomen per soort"
+
+    def test_concept_scheme_has_default_language(self):
+        assert trees.concept_scheme.default_language == "nl"
+
     def test_collection_has_scheme(self):
         coll = trees.get_by_id(3)
         assert isinstance(coll.concept_scheme, ConceptScheme)
@@ -799,6 +818,10 @@ class TestGeoDictionaryProvider:
     def test_get_metadata(self):
         assert {"id": "GEOGRAPHY", "subject": []} == geo.get_metadata()
 
+    def test_concept_default_language_without_provider_default(self):
+        con = geo.get_by_id(1)
+        assert con.default_language is None
+
     def test_concept_has_scheme(self):
         con = geo.get_by_id(1)
         assert isinstance(con.concept_scheme, ConceptScheme)
@@ -1021,3 +1044,17 @@ class TestSimpleCsvProvider:
         csv_provider.case_insensitive = False
         sausages = csv_provider.find({"label": "Sausage"})
         assert 1 == len(sausages)
+
+    def test_default_language_propagated(self, csv_file):
+        from skosprovider.uri import UriPatternGenerator
+
+        reader = csv.reader(csv_file)
+        provider = SimpleCsvProvider(
+            {"id": "MENU", "default_language": "en"},
+            reader,
+            uri_generator=UriPatternGenerator("http://id.python.org/menu/%s"),
+            concept_scheme=ConceptScheme("http://id.python.org/menu"),
+        )
+        eb = provider.get_by_id(1)
+        assert eb.default_language == "en"
+        assert provider.concept_scheme.default_language == "en"

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -9,6 +9,7 @@ from skosprovider.skos import Collection
 from skosprovider.skos import Concept
 from skosprovider.skos import ConceptScheme
 from skosprovider.skos import Note
+from skosprovider.uri import UriPatternGenerator
 
 larch = {
     "id": "1",
@@ -1046,8 +1047,6 @@ class TestSimpleCsvProvider:
         assert 1 == len(sausages)
 
     def test_default_language_propagated(self, csv_file):
-        from skosprovider.uri import UriPatternGenerator
-
         reader = csv.reader(csv_file)
         provider = SimpleCsvProvider(
             {"id": "MENU", "default_language": "en"},

--- a/tests/test_skos.py
+++ b/tests/test_skos.py
@@ -310,6 +310,32 @@ class TestConceptScheme:
         with pytest.raises(ValueError):
             ConceptScheme(uri=None)
 
+    def test_default_language(self):
+        cs = ConceptScheme(uri="urn:x-skosprovider:gemeenten")
+        assert cs.default_language is None
+
+    def test_default_language_set(self):
+        cs = ConceptScheme(uri="urn:x-skosprovider:gemeenten", default_language="nl")
+        assert cs.default_language == "nl"
+
+    def test_label_uses_default_language(self):
+        labels = self._get_labels()
+        cs = ConceptScheme(
+            uri="urn:x-skosprovider:gemeenten", labels=labels, default_language="en"
+        )
+        assert cs.label().label == "Communities"
+        cs_nl = ConceptScheme(
+            uri="urn:x-skosprovider:gemeenten", labels=labels, default_language="nl"
+        )
+        assert cs_nl.label().label == "Gemeenten"
+
+    def test_label_explicit_overrides_default(self):
+        labels = self._get_labels()
+        cs = ConceptScheme(
+            uri="urn:x-skosprovider:gemeenten", labels=labels, default_language="nl"
+        )
+        assert cs.label("en").label == "Communities"
+
 
 class TestConcept:
 
@@ -389,6 +415,45 @@ class TestConcept:
         assert 1 == len(c.sources)
         assert "My citation" == c.sources[0].citation
 
+    def test_default_language(self):
+        c = Concept(1)
+        assert c.default_language is None
+
+    def test_default_language_set(self):
+        c = Concept(1, default_language="nl")
+        assert c.default_language == "nl"
+
+    def test_label_uses_default_language(self):
+        labels = self._get_labels()
+        c = Concept(1, labels=labels, default_language="en")
+        assert c.label().label == "Knocke-Heyst"
+        c_nl = Concept(1, labels=labels, default_language="nl")
+        assert c_nl.label().label == "Knokke-Heist"
+
+    def test_label_explicit_overrides_default(self):
+        labels = self._get_labels()
+        c = Concept(1, labels=labels, default_language="nl")
+        assert c.label("en").label == "Knocke-Heyst"
+
+    def test_label_none_uses_default_language(self):
+        labels = self._get_labels()
+        c = Concept(1, labels=labels, default_language="en")
+        assert c.label(None).label == "Knocke-Heyst"
+        c_nl = Concept(1, labels=labels, default_language="nl")
+        assert c_nl.label(None).label == "Knokke-Heist"
+
+    def test_label_none_without_default_returns_any(self):
+        labels = self._get_labels()
+        c = Concept(1, labels=labels)
+        assert c.label(None) is not None
+
+    def test_sortkey_uses_default_language(self):
+        labels = self._get_labels()
+        c = Concept(1, labels=labels, default_language="en")
+        assert c._sortkey("label") == "knocke-heyst"
+        c_nl = Concept(1, labels=labels, default_language="nl")
+        assert c_nl._sortkey("label") == "knokke-heist"
+
 
 class TestCollection:
 
@@ -462,6 +527,39 @@ class TestCollection:
         assert coll.infer_concept_relations
         coll = Collection(id=1, infer_concept_relations=False)
         assert not coll.infer_concept_relations
+
+    def test_default_language(self):
+        coll = Collection(1)
+        assert coll.default_language is None
+
+    def test_default_language_set(self):
+        coll = Collection(1, default_language="nl")
+        assert coll.default_language == "nl"
+
+    def test_label_uses_default_language(self):
+        labels = self._get_labels()
+        en_label = Label("Subcommunities", type="prefLabel", language="en")
+        labels.append(en_label)
+        coll = Collection(350, labels=labels, default_language="en")
+        assert coll.label().label == "Subcommunities"
+        coll_nl = Collection(350, labels=labels, default_language="nl")
+        assert coll_nl.label().label == "Deelgemeenten"
+
+    def test_label_explicit_overrides_default(self):
+        labels = self._get_labels()
+        en_label = Label("Subcommunities", type="prefLabel", language="en")
+        labels.append(en_label)
+        coll = Collection(350, labels=labels, default_language="nl")
+        assert coll.label("en").label == "Subcommunities"
+
+    def test_sortkey_uses_default_language(self):
+        labels = self._get_labels()
+        en_label = Label("Subcommunities", type="prefLabel", language="en")
+        labels.append(en_label)
+        coll = Collection(350, labels=labels, default_language="en")
+        assert coll._sortkey("label") == "subcommunities"
+        coll_nl = Collection(350, labels=labels, default_language="nl")
+        assert coll_nl._sortkey("label") == "deelgemeenten"
 
 
 class TestDictToNoteFunction:
@@ -563,8 +661,6 @@ class TestLabelFunction:
         assert und == label(labels, "en-GB")
         assert und == label(labels, "und")
         assert und == label(labels, ["und"])
-        assert und == label(labels, "any")
-        assert und == label(labels, ["any"])
         assert und == label(labels, None)
 
     def test_label_pref_nl_and_en(self):
@@ -670,8 +766,7 @@ class TestLabelFunction:
         labels = [kh, ch, khen]
         assert [kh, ch] == filter_labels_by_language(labels, "nl-BE")
         assert [] == filter_labels_by_language(labels, "nl")
-        assert [kh, ch] == filter_labels_by_language(labels, "nl", True)
-        assert labels == filter_labels_by_language(labels, "any")
+        assert [khen] == filter_labels_by_language(labels, "en-GB")
 
     def test_filter_labels_by_language_unexisting(self):
         kh = self._get_knokke_heist_nl()


### PR DESCRIPTION
#164

I hope these changes capture the intend of https://github.com/OnroerendErfgoed/skosprovider/issues/164#issuecomment-4215463247

  New feature: per-object default language                                                                                                                                                                                          
  - Added default_language attribute + constructor kwarg to ConceptScheme, Concept, and Collection. When set, .label() and ._sortkey() fall back to this language if the caller doesn't specify one.                                
  - Providers now read metadata["default_language"] and propagate it onto their concept_scheme and all concepts/collections (MemoryProvider._set_concepts, inherited by DictionaryProvider and SimpleCsvProvider).                  
                                                                                                                                                                                                                  
  Language resolution rewrite (label() function)                                                                                                                                                                                    
  - Dropped the magic "any" string; pass None instead for "no preference".                                                                                                                                                          
  - None no longer means "labels tagged as und" ? use the tag "und" explicitly.                                                                                                                                                     
  - Subtag matching now walks the fallback chain (nl-BE-Latn ? nl-BE ? nl) before collapsing to the primary subtag, instead of jumping straight from exact to primary.                                                              
  - filter_labels_by_language lost its broader kwarg and "any" handling (now purely exact match).                                                                                                                                   
  - Added module-level helpers _language_fallback_chain, _primary_language, _pick_best_label, and _resolve_language.                                                                                        
                                                                                                                                                                                                                                    
  API renames / breaking changes (2.0.0)                                                                                                                                                                                            
  - MemoryProvider.__init__ / DictionaryProvider.__init__: positional param list ? concepts_and_collections (avoids shadowing the builtin).                                                                                                         
  - VocabularyProvider._get_language() no longer falls back to 'en'; returns None when no default is configured.                                                                                                                    
  - _sort default language changed from "any" to None.                                                          
                                                                                                                                                                                                                                    
  Docs & tests                                                                                                                                                                                                                      
  - Rewrote label() docstring to describe the new resolution rules.                                                                                                                                                                 
  - Added tests covering default-language propagation, explicit overrides, None fallback, _sortkey behavior, and provider-level propagation.                                                                                        
  - Removed tests that asserted the old "any" / broader semantics.  
