### PR TITLE
fix naming

### DIFF
--- a/skosprovider/jsonld.py
+++ b/skosprovider/jsonld.py
@@ -137,10 +137,14 @@ def jsonld_dumper(provider, context=None, language=None):
             provider, None, relations_profile="uri", language=language
         )
     )
-    for c in provider.get_all():
+    for concept_or_collection in provider.get_all():
         doc["@graph"].append(
             jsonld_c_dumper(
-                provider, c["id"], None, relations_profile="uri", language=language
+                provider,
+                concept_or_collection["id"],
+                None,
+                relations_profile="uri",
+                language=language,
             )
         )
     return doc
@@ -162,122 +166,156 @@ def jsonld_c_dumper(
 
     :rtype: A `dict`
     """
-    c = provider.get_by_id(id)
-    doc = _jsonld_c_basic_renderer(c, language)
+    concept_or_collection = provider.get_by_id(id)
+    doc = _jsonld_c_basic_renderer(concept_or_collection, language)
     if context:
         doc["@context"] = context
     if relations_profile == "partial":
-        doc["concept_scheme"] = _jsonld_cs_basic_renderer(c.concept_scheme, language)
+        doc["concept_scheme"] = _jsonld_cs_basic_renderer(
+            concept_or_collection.concept_scheme, language
+        )
     else:
-        doc["concept_scheme"] = c.concept_scheme.uri
+        doc["concept_scheme"] = concept_or_collection.concept_scheme.uri
     dataset_uri = provider.get_metadata().get("dataset", {}).get("uri", None)
     if dataset_uri:
         doc["in_dataset"] = dataset_uri
-    doc.update(_jsonld_labels_renderer(c))
-    doc.update(_jsonld_labels_xl_renderer(c))
-    doc.update(_jsonld_notes_renderer(c))
-    doc.update(_jsonld_sources_renderer(c))
-    doc.update(_jsonld_member_of_renderer(c, provider, relations_profile, language))
-    if c.type == "concept":
-        doc.update(_jsonld_matches_renderer(c))
-        doc.update(_jsonld_broader_renderer(c, provider, relations_profile, language))
-        doc.update(_jsonld_narrower_renderer(c, provider, relations_profile, language))
-        doc.update(_jsonld_related_renderer(c, provider, relations_profile, language))
+    doc.update(_jsonld_labels_renderer(concept_or_collection))
+    doc.update(_jsonld_labels_xl_renderer(concept_or_collection))
+    doc.update(_jsonld_notes_renderer(concept_or_collection))
+    doc.update(_jsonld_sources_renderer(concept_or_collection))
+    doc.update(
+        _jsonld_member_of_renderer(
+            concept_or_collection, provider, relations_profile, language
+        )
+    )
+    if concept_or_collection.type == "concept":
+        doc.update(_jsonld_matches_renderer(concept_or_collection))
         doc.update(
-            _jsonld_subordinate_arrays_renderer(
-                c, provider, relations_profile, language
+            _jsonld_broader_renderer(
+                concept_or_collection, provider, relations_profile, language
             )
         )
-    elif c.type == "collection":
-        doc["infer_concept_relations"] = True
-        doc.update(_jsonld_members_renderer(c, provider, relations_profile, language))
         doc.update(
-            _jsonld_superordinates_renderer(c, provider, relations_profile, language)
+            _jsonld_narrower_renderer(
+                concept_or_collection, provider, relations_profile, language
+            )
+        )
+        doc.update(
+            _jsonld_related_renderer(
+                concept_or_collection, provider, relations_profile, language
+            )
+        )
+        doc.update(
+            _jsonld_subordinate_arrays_renderer(
+                concept_or_collection, provider, relations_profile, language
+            )
+        )
+    elif concept_or_collection.type == "collection":
+        doc["infer_concept_relations"] = True
+        doc.update(
+            _jsonld_members_renderer(
+                concept_or_collection, provider, relations_profile, language
+            )
+        )
+        doc.update(
+            _jsonld_superordinates_renderer(
+                concept_or_collection, provider, relations_profile, language
+            )
         )
     return doc
 
 
-def _jsonld_c_basic_renderer(c, language="en"):
-    doc = {"id": c.id, "uri": c.uri, "type": c.type}
-    label = c.label(language)
+def _jsonld_c_basic_renderer(concept_or_collection, language="en"):
+    doc = {
+        "id": concept_or_collection.id,
+        "uri": concept_or_collection.uri,
+        "type": concept_or_collection.type,
+    }
+    label = concept_or_collection.label(language)
     if label:
         doc["label"] = label.label
     return doc
 
 
-def _jsonld_cs_basic_renderer(cs, language="en"):
-    doc = {"uri": cs.uri, "type": "skos:ConceptScheme"}
-    label = cs.label(language)
+def _jsonld_cs_basic_renderer(concept_scheme, language="en"):
+    doc = {"uri": concept_scheme.uri, "type": "skos:ConceptScheme"}
+    label = concept_scheme.label(language)
     if label:
         doc["label"] = label.label
     return doc
 
 
-def _jsonld_labels_renderer(c):
-    if not len(c.labels):
+def _jsonld_labels_renderer(concept_or_collection):
+    if not len(concept_or_collection.labels):
         return {}
     doc = {"labels": {}}
 
-    def lbl_renderer(label):
+    def label_renderer(label):
         language = extract_language(label.language)
         return {"language": language, "@language": language, "lbl": label.label}
 
-    ltypemap = {
+    label_type_map = {
         "prefLabel": "pref_labels",
         "altLabel": "alt_labels",
         "hiddenLabel": "hidden_labels",
         "sortLabel": "hidden_labels",
     }
-    for label in c.labels:
-        doc["labels"].setdefault(ltypemap[label.type], []).append(lbl_renderer(label))
+    for label in concept_or_collection.labels:
+        doc["labels"].setdefault(label_type_map[label.type], []).append(
+            label_renderer(label)
+        )
     return doc
 
 
-def _jsonld_labels_xl_renderer(c):
-    if not len([label for label in c.labels if label.is_xl()]):
+def _jsonld_labels_xl_renderer(concept_or_collection):
+    if not len([label for label in concept_or_collection.labels if label.is_xl()]):
         return {}
     doc = {"labels_xl": {}}
 
-    def lbl_xl_renderer(label):
+    def label_xl_renderer(label):
         language = extract_language(label.language)
-        lbl = {
+        rendered_label = {
             "uri": label.uri,
             "type": "skosxl:Label",
             "skosxl:literalForm": {"@language": language, "lbl": label.label},
         }
         if len(label.label_types):
-            lbl["label_types"] = label.label_types
-        return lbl
+            rendered_label["label_types"] = label.label_types
+        return rendered_label
 
-    ltypemap = {
+    label_type_map = {
         "prefLabel": "pref_labels_xl",
         "altLabel": "alt_labels_xl",
         "hiddenLabel": "hidden_labels_xl",
         "sortLabel": "hidden_labels_xl",
     }
-    for label in c.labels:
+    for label in concept_or_collection.labels:
         if label.is_xl():
-            doc["labels_xl"].setdefault(ltypemap[label.type], []).append(
-                lbl_xl_renderer(label)
+            doc["labels_xl"].setdefault(label_type_map[label.type], []).append(
+                label_xl_renderer(label)
             )
     return doc
 
 
-def _jsonld_notes_renderer(c):
-    if not len(c.notes):
+def _jsonld_notes_renderer(concept_or_collection):
+    if not len(concept_or_collection.notes):
         return {}
     doc = {"notes": {}}
 
-    def nt_renderer(n):
-        language = extract_language(n.language)
-        note = {"language": language, "@language": language, "nt": n.note}
-        if n.markup is not None:
-            del note["@language"]
-            note["nt"] = add_lang_to_html(note["nt"], language)
-            note["@type"] = n.markup
-        return note
+    def note_renderer(note):
+        language = extract_language(note.language)
+        rendered_note = {
+            "language": language,
+            "@language": language,
+            "nt": note.note,
+        }
+        if note.markup is not None:
+            del rendered_note["@language"]
+            rendered_note["nt"] = add_lang_to_html(rendered_note["nt"], language)
+            rendered_note["@type"] = note.markup
+        return rendered_note
 
-    ntypemap = {
+    note_type_map = {
         "note": "general_notes",
         "scopeNote": "scope_notes",
         "definition": "definitions",
@@ -286,88 +324,118 @@ def _jsonld_notes_renderer(c):
         "changeNote": "change_notes",
         "example": "examples",
     }
-    for n in c.notes:
-        doc["notes"].setdefault(ntypemap[n.type], []).append(nt_renderer(n))
+    for note in concept_or_collection.notes:
+        doc["notes"].setdefault(note_type_map[note.type], []).append(
+            note_renderer(note)
+        )
     return doc
 
 
-def _jsonld_sources_renderer(c):
-    if not len(c.sources):
+def _jsonld_sources_renderer(concept_or_collection):
+    if not len(concept_or_collection.sources):
         return {}
     doc = {"sources": []}
 
-    def s_renderer(s):
-        source = {
+    def source_renderer(source):
+        rendered_source = {
             "type": "dct:BibliographicResource",
-            "citations": [{"ct": s.citation}],
+            "citations": [{"ct": source.citation}],
         }
-        if s.markup is not None:
-            source["citations"][0]["@type"] = s.markup
-        return source
+        if source.markup is not None:
+            rendered_source["citations"][0]["@type"] = source.markup
+        return rendered_source
 
-    for s in c.sources:
-        doc["sources"].append(s_renderer(s))
+    for source in concept_or_collection.sources:
+        doc["sources"].append(source_renderer(source))
     return doc
 
 
-def _jsonld_matches_renderer(c):
-    if not any([len(matches) for matches in c.matches.values()]):
+def _jsonld_matches_renderer(concept_or_collection):
+    if not any([len(matches) for matches in concept_or_collection.matches.values()]):
         return {}
     doc = {"matches": {}}
-    for matchtype, matches in c.matches.items():
+    for matchtype, matches in concept_or_collection.matches.items():
         if len(matches):
             doc["matches"].setdefault(f"{matchtype}_matches", []).extend(matches)
     return doc
 
 
-def _jsonld_superordinates_renderer(c, provider, profile="partial", language="en"):
-    return _jsonld_relation_renderer(c, provider, "superordinates", profile, language)
-
-
-def _jsonld_members_renderer(c, provider, profile="partial", language="en"):
-    return _jsonld_relation_renderer(c, provider, "members", profile, language)
-
-
-def _jsonld_member_of_renderer(c, provider, profile="partial", language="en"):
-    return _jsonld_relation_renderer(c, provider, "member_of", profile, language)
-
-
-def _jsonld_broader_renderer(c, provider, profile="partial", language="en"):
-    return _jsonld_relation_renderer(c, provider, "broader", profile, language)
-
-
-def _jsonld_narrower_renderer(c, provider, profile="partial", language="en"):
-    return _jsonld_relation_renderer(c, provider, "narrower", profile, language)
-
-
-def _jsonld_related_renderer(c, provider, profile="partial", language="en"):
-    return _jsonld_relation_renderer(c, provider, "related", profile, language)
-
-
-def _jsonld_subordinate_arrays_renderer(c, provider, profile="partial", language="en"):
+def _jsonld_superordinates_renderer(
+    concept_or_collection, provider, profile="partial", language="en"
+):
     return _jsonld_relation_renderer(
-        c, provider, "subordinate_arrays", profile, language
+        concept_or_collection, provider, "superordinates", profile, language
     )
 
 
-def _jsonld_relation_renderer(c, provider, relation, profile="partial", language="en"):
+def _jsonld_members_renderer(
+    concept_or_collection, provider, profile="partial", language="en"
+):
+    return _jsonld_relation_renderer(
+        concept_or_collection, provider, "members", profile, language
+    )
+
+
+def _jsonld_member_of_renderer(
+    concept_or_collection, provider, profile="partial", language="en"
+):
+    return _jsonld_relation_renderer(
+        concept_or_collection, provider, "member_of", profile, language
+    )
+
+
+def _jsonld_broader_renderer(
+    concept_or_collection, provider, profile="partial", language="en"
+):
+    return _jsonld_relation_renderer(
+        concept_or_collection, provider, "broader", profile, language
+    )
+
+
+def _jsonld_narrower_renderer(
+    concept_or_collection, provider, profile="partial", language="en"
+):
+    return _jsonld_relation_renderer(
+        concept_or_collection, provider, "narrower", profile, language
+    )
+
+
+def _jsonld_related_renderer(
+    concept_or_collection, provider, profile="partial", language="en"
+):
+    return _jsonld_relation_renderer(
+        concept_or_collection, provider, "related", profile, language
+    )
+
+
+def _jsonld_subordinate_arrays_renderer(
+    concept_or_collection, provider, profile="partial", language="en"
+):
+    return _jsonld_relation_renderer(
+        concept_or_collection, provider, "subordinate_arrays", profile, language
+    )
+
+
+def _jsonld_relation_renderer(
+    concept_or_collection, provider, relation, profile="partial", language="en"
+):
     doc = {relation: []}
-    for m in getattr(c, relation):
-        relc = provider.get_by_id(m)
+    for member_id in getattr(concept_or_collection, relation):
+        related_concept = provider.get_by_id(member_id)
         if profile == "partial":
-            doc[relation].append(_jsonld_c_basic_renderer(relc, language))
+            doc[relation].append(_jsonld_c_basic_renderer(related_concept, language))
         else:
-            doc[relation].append(relc.uri)
+            doc[relation].append(related_concept.uri)
     return doc
 
 
 def _jsonld_topconcepts_renderer(provider, profile="partial"):
     doc = {"top_concepts": []}
-    for c in provider.get_top_concepts():
+    for top_concept in provider.get_top_concepts():
         if profile == "partial":
-            doc["top_concepts"].append(c)
+            doc["top_concepts"].append(top_concept)
         else:
-            doc["top_concepts"].append(c["uri"])
+            doc["top_concepts"].append(top_concept["uri"])
     return doc
 
 

--- a/skosprovider/providers.py
+++ b/skosprovider/providers.py
@@ -469,27 +469,33 @@ class MemoryProvider(VocabularyProvider):
 
     def get_by_id(self, id):
         id = str(id)
-        for c in self.list:
-            if str(c.id) == id:
-                return c
+        for concept_or_collection in self.list:
+            if str(concept_or_collection.id) == id:
+                return concept_or_collection
         return False
 
     def get_by_uri(self, uri):
         uri = str(uri)
-        for c in self.list:
-            if str(c.uri) == uri:
-                return c
+        for concept_or_collection in self.list:
+            if str(concept_or_collection.uri) == uri:
+                return concept_or_collection
         return False
 
     def find(self, query, **kwargs):
         query = self._normalise_query(query)
-        filtered = [c for c in self.list if self._include_in_find(c, query)]
+        filtered = [
+            concept_or_collection
+            for concept_or_collection in self.list
+            if self._include_in_find(concept_or_collection, query)
+        ]
         language = self._get_language(**kwargs)
         sort = self._get_sort(**kwargs)
         reverse_sort = self._get_sort_order(**kwargs) == "desc"
         return [
-            self._get_find_dict(c, **kwargs)
-            for c in self._sort(filtered, sort, language, reverse_sort)
+            self._get_find_dict(concept_or_collection, **kwargs)
+            for concept_or_collection in self._sort(
+                filtered, sort, language, reverse_sort
+            )
         ]
 
     def _normalise_query(self, query):
@@ -503,16 +509,16 @@ class MemoryProvider(VocabularyProvider):
             query["type"] = "concept"
         return query
 
-    def _include_in_find(self, c, query):
+    def _include_in_find(self, concept_or_collection, query):
         """
-        :param c: A :class:`skosprovider.skos.Concept` or
+        :param concept_or_collection: A :class:`skosprovider.skos.Concept` or
             :class:`skosprovider.skos.Collection`.
         :param query: A dict that can be used to express a query.
         :rtype: boolean
         """
         include = True
         if include and "type" in query:
-            include = query["type"] == c.type
+            include = query["type"] == concept_or_collection.type
         if include and "label" in query:
 
             def finder(label, query):
@@ -521,49 +527,57 @@ class MemoryProvider(VocabularyProvider):
                 else:
                     return label.label.upper().find(query["label"].upper())
 
-            include = any([finder(label, query) >= 0 for label in c.labels])
+            include = any(
+                [finder(label, query) >= 0 for label in concept_or_collection.labels]
+            )
         if include and "collection" in query:
-            coll = self.get_by_id(query["collection"]["id"])
-            if not coll or not isinstance(coll, Collection):
+            collection = self.get_by_id(query["collection"]["id"])
+            if not collection or not isinstance(collection, Collection):
                 raise ValueError(
                     "You are searching for items in an unexisting collection."
                 )
             if "depth" in query["collection"] and query["collection"]["depth"] == "all":
-                members = self.expand(coll.id)
+                members = self.expand(collection.id)
             else:
-                members = coll.members
-            include = any([True for id in members if str(id) == str(c.id)])
-        if include and "matches" in query and c.type == "concept":
+                members = collection.members
+            include = any(
+                [True for id in members if str(id) == str(concept_or_collection.id)]
+            )
+        if include and "matches" in query and concept_or_collection.type == "concept":
             match_uri = query["matches"].get("uri", None)
             if not match_uri:
                 raise ValueError("Please provide a URI to match with.")
             match_type = query["matches"].get("type", None)
             if not match_type:
                 matches = []
-                for mt in c.matchtypes:
-                    matches.extend(c.matches[mt])
+                for matchtype in concept_or_collection.matchtypes:
+                    matches.extend(concept_or_collection.matches[matchtype])
             else:
-                matches = c.matches.get(match_type, [])[:]
+                matches = concept_or_collection.matches.get(match_type, [])[:]
                 if match_type == "close":
-                    matches.extend(c.matches.get("exact", []))
+                    matches.extend(concept_or_collection.matches.get("exact", []))
             include = any([True for uri in matches if uri == match_uri])
         return include
 
-    def _get_find_dict(self, c, **kwargs):
+    def _get_find_dict(self, concept_or_collection, **kwargs):
         """
         Return a dict that can be used in the return list of the :meth:`find`
         method.
 
-        :param c: A :class:`skosprovider.skos.Concept` or
+        :param concept_or_collection: A :class:`skosprovider.skos.Concept` or
             :class:`skosprovider.skos.Collection`.
         :rtype: dict
         """
         language = self._get_language(**kwargs)
         return {
-            "id": c.id,
-            "uri": c.uri,
-            "type": c.type,
-            "label": None if c.label() is None else c.label(language).label,
+            "id": concept_or_collection.id,
+            "uri": concept_or_collection.uri,
+            "type": concept_or_collection.type,
+            "label": (
+                None
+                if concept_or_collection.label() is None
+                else concept_or_collection.label(language).label
+            ),
         }
 
     def get_all(self, **kwargs):
@@ -571,36 +585,38 @@ class MemoryProvider(VocabularyProvider):
         sort = self._get_sort(**kwargs)
         reverse_sort = self._get_sort_order(**kwargs) == "desc"
         return [
-            self._get_find_dict(c, **kwargs)
-            for c in self._sort(self.list, sort, language, reverse_sort)
+            self._get_find_dict(concept_or_collection, **kwargs)
+            for concept_or_collection in self._sort(
+                self.list, sort, language, reverse_sort
+            )
         ]
 
-    def _is_top_concept(self, c):
+    def _is_top_concept(self, concept_or_collection):
         """
         Is this a top concept or not?
 
         A top concept is a concept that has no broader concepts directly or
         indirectly (because it might be part of a thesaurus array).
 
-        :param c: A :class:`skosprovider.skos.Concept` or
+        :param concept_or_collection: A :class:`skosprovider.skos.Concept` or
             :class:`skosprovider.skos.Collection`.
         :rtype: boolean
         """
-        if not isinstance(c, Concept):
+        if not isinstance(concept_or_collection, Concept):
             return False
-        if len(c.broader):
+        if len(concept_or_collection.broader):
             return False
 
-        def _has_higher_concept(c):
-            for collid in c.member_of:
-                coll = self.get_by_id(collid)
-                if coll.infer_concept_relations and (
-                    coll.superordinates or _has_higher_concept(coll)
+        def _has_higher_concept(concept_or_collection):
+            for collection_id in concept_or_collection.member_of:
+                collection = self.get_by_id(collection_id)
+                if collection.infer_concept_relations and (
+                    collection.superordinates or _has_higher_concept(collection)
                 ):
                     return True
             return False
 
-        return not _has_higher_concept(c)
+        return not _has_higher_concept(concept_or_collection)
 
     def get_top_concepts(self, **kwargs):
         language = self._get_language(**kwargs)
@@ -614,21 +630,21 @@ class MemoryProvider(VocabularyProvider):
 
     def expand(self, id):
         id = str(id)
-        for c in self.list:
-            if str(c.id) == id:
-                if isinstance(c, Concept):
-                    ret = {c.id}
-                    for cid in c.narrower:
-                        ret |= set(self.expand(cid))
-                    for collid in c.subordinate_arrays:
-                        coll = self.get_by_id(collid)
-                        if coll.infer_concept_relations:
-                            ret |= set(self.expand(collid))
+        for concept_or_collection in self.list:
+            if str(concept_or_collection.id) == id:
+                if isinstance(concept_or_collection, Concept):
+                    ret = {concept_or_collection.id}
+                    for narrower_id in concept_or_collection.narrower:
+                        ret |= set(self.expand(narrower_id))
+                    for collection_id in concept_or_collection.subordinate_arrays:
+                        collection = self.get_by_id(collection_id)
+                        if collection.infer_concept_relations:
+                            ret |= set(self.expand(collection_id))
                     return list(ret)
-                elif isinstance(c, Collection):
+                elif isinstance(concept_or_collection, Collection):
                     ret = set()
-                    for m in c.members:
-                        ret |= set(self.expand(m))
+                    for member in concept_or_collection.members:
+                        ret |= set(self.expand(member))
                     return list(ret)
         return False
 
@@ -636,48 +652,65 @@ class MemoryProvider(VocabularyProvider):
         language = self._get_language(**kwargs)
         sort = self._get_sort(**kwargs)
         sort_order = self._get_sort_order(**kwargs)
-        td = [
-            c
-            for c in self.list
+        top_display = [
+            concept_or_collection
+            for concept_or_collection in self.list
             if (
-                isinstance(c, Concept) and len(c.broader) == 0 and len(c.member_of) == 0
+                isinstance(concept_or_collection, Concept)
+                and len(concept_or_collection.broader) == 0
+                and len(concept_or_collection.member_of) == 0
             )
             or (
-                isinstance(c, Collection)
-                and len(c.superordinates) == 0
-                and len(c.member_of) == 0
+                isinstance(concept_or_collection, Collection)
+                and len(concept_or_collection.superordinates) == 0
+                and len(concept_or_collection.member_of) == 0
             )
         ]
         return [
             {
-                "id": c.id,
-                "uri": c.uri,
-                "type": c.type,
-                "label": None if c.label() is None else c.label(language).label,
+                "id": concept_or_collection.id,
+                "uri": concept_or_collection.uri,
+                "type": concept_or_collection.type,
+                "label": (
+                    None
+                    if concept_or_collection.label() is None
+                    else concept_or_collection.label(language).label
+                ),
             }
-            for c in self._sort(td, sort, language, sort_order == "desc")
+            for concept_or_collection in self._sort(
+                top_display, sort, language, sort_order == "desc"
+            )
         ]
 
     def get_children_display(self, id, **kwargs):
-        c = self.get_by_id(id)
-        if not c:
+        concept_or_collection = self.get_by_id(id)
+        if not concept_or_collection:
             return False
         language = self._get_language(**kwargs)
         sort = self._get_sort(**kwargs)
         sort_order = self._get_sort_order(**kwargs)
-        if isinstance(c, Concept):
-            display_children = c.subordinate_arrays + c.narrower
+        if isinstance(concept_or_collection, Concept):
+            display_children = (
+                concept_or_collection.subordinate_arrays
+                + concept_or_collection.narrower
+            )
         else:
-            display_children = c.members
-        dc = [self.get_by_id(dcid) for dcid in display_children]
+            display_children = concept_or_collection.members
+        display_children_list = [
+            self.get_by_id(display_child_id) for display_child_id in display_children
+        ]
         return [
             {
-                "id": co.id,
-                "uri": co.uri,
-                "type": co.type,
-                "label": None if co.label() is None else co.label(language).label,
+                "id": child.id,
+                "uri": child.uri,
+                "type": child.type,
+                "label": (
+                    None if child.label() is None else child.label(language).label
+                ),
             }
-            for co in self._sort(dc, sort, language, sort_order == "desc")
+            for child in self._sort(
+                display_children_list, sort, language, sort_order == "desc"
+            )
         ]
 
 
@@ -690,7 +723,9 @@ class DictionaryProvider(MemoryProvider):
 
     def __init__(self, metadata, list, **kwargs):
         super().__init__(metadata, [], **kwargs)
-        self.list = [self._from_dict(c) for c in list]
+        self.list = [
+            self._from_dict(concept_or_collection) for concept_or_collection in list
+        ]
 
     def _from_dict(self, data):
         if "type" in data and data["type"] == "collection":

--- a/skosprovider/providers.py
+++ b/skosprovider/providers.py
@@ -633,17 +633,19 @@ class MemoryProvider(VocabularyProvider):
         for concept_or_collection in self.list:
             if str(concept_or_collection.id) == id:
                 if isinstance(concept_or_collection, Concept):
-                    ret = {concept_or_collection.id}
-                    for narrower_id in concept_or_collection.narrower:
+                    concept = concept_or_collection
+                    ret = {concept.id}
+                    for narrower_id in concept.narrower:
                         ret |= set(self.expand(narrower_id))
-                    for collection_id in concept_or_collection.subordinate_arrays:
+                    for collection_id in concept.subordinate_arrays:
                         collection = self.get_by_id(collection_id)
                         if collection.infer_concept_relations:
                             ret |= set(self.expand(collection_id))
                     return list(ret)
                 elif isinstance(concept_or_collection, Collection):
+                    collection = concept_or_collection
                     ret = set()
-                    for member in concept_or_collection.members:
+                    for member in collection.members:
                         ret |= set(self.expand(member))
                     return list(ret)
         return False

--- a/skosprovider/registry.py
+++ b/skosprovider/registry.py
@@ -124,11 +124,11 @@ class Registry:
             `False` if the id is unknown.
         """
         if id in self.providers:
-            p = self.providers.get(id, False)
+            provider = self.providers.get(id, False)
             del self.providers[id]
-            cs_uri = p.get_vocabulary_uri()
-            del self.concept_scheme_uri_map[cs_uri]
-            return p
+            concept_scheme_uri = provider.get_vocabulary_uri()
+            del self.concept_scheme_uri_map[concept_scheme_uri]
+            return provider
         elif id in self.concept_scheme_uri_map:
             id = self.concept_scheme_uri_map[id]
             return self.remove_provider(id)
@@ -177,12 +177,18 @@ class Registry:
         """
         if "ids" in kwargs:
             ids = [self.concept_scheme_uri_map.get(id, id) for id in kwargs["ids"]]
-            providers = [self.providers[k] for k in self.providers.keys() if k in ids]
+            providers = [
+                self.providers[provider_id]
+                for provider_id in self.providers.keys()
+                if provider_id in ids
+            ]
         else:
             providers = list(self.providers.values())
         if "subject" in kwargs:
             providers = [
-                p for p in providers if kwargs["subject"] in p.metadata["subject"]
+                provider
+                for provider in providers
+                if kwargs["subject"] in provider.metadata["subject"]
             ]
         return providers
 
@@ -244,17 +250,20 @@ class Registry:
         if "providers" not in kwargs:
             providers = self.get_providers()
         else:
-            pargs = kwargs["providers"]
-            if isinstance(pargs, list):
-                providers = self.get_providers(ids=pargs)
+            provider_args = kwargs["providers"]
+            if isinstance(provider_args, list):
+                providers = self.get_providers(ids=provider_args)
             else:
-                providers = self.get_providers(**pargs)
+                providers = self.get_providers(**provider_args)
         kwarguments = {}
         if "language" in kwargs:
             kwarguments["language"] = kwargs["language"]
         return [
-            {"id": p.get_vocabulary_id(), "concepts": p.find(query, **kwarguments)}
-            for p in providers
+            {
+                "id": provider.get_vocabulary_id(),
+                "concepts": provider.find(query, **kwarguments),
+            }
+            for provider in providers
         ]
 
     def get_all(self, **kwargs):
@@ -281,8 +290,11 @@ class Registry:
         if "language" in kwargs:
             kwarguments["language"] = kwargs["language"]
         return [
-            {"id": p.get_vocabulary_id(), "concepts": p.get_all(**kwarguments)}
-            for p in self.providers.values()
+            {
+                "id": provider.get_vocabulary_id(),
+                "concepts": provider.get_all(**kwarguments),
+            }
+            for provider in self.providers.values()
         ]
 
     def get_by_uri(self, uri):
@@ -299,18 +311,20 @@ class Registry:
         if not is_uri(uri):
             raise ValueError(f"{uri} is not a valid URI.")
         # Check if there's a provider that's more likely to have the URI
-        csuris = [
-            csuri
-            for csuri in self.concept_scheme_uri_map.keys()
-            if uri.startswith(csuri)
+        concept_scheme_uris = [
+            concept_scheme_uri
+            for concept_scheme_uri in self.concept_scheme_uri_map.keys()
+            if uri.startswith(concept_scheme_uri)
         ]
-        for csuri in csuris:
-            c = self.get_provider(csuri).get_by_uri(uri)
-            if c:
-                return c
+        for concept_scheme_uri in concept_scheme_uris:
+            concept_or_collection = self.get_provider(concept_scheme_uri).get_by_uri(
+                uri
+            )
+            if concept_or_collection:
+                return concept_or_collection
         # Check all providers
-        for p in self.providers.values():
-            c = p.get_by_uri(uri)
-            if c:
-                return c
+        for provider in self.providers.values():
+            concept_or_collection = provider.get_by_uri(uri)
+            if concept_or_collection:
+                return concept_or_collection
         return False

--- a/skosprovider/utils.py
+++ b/skosprovider/utils.py
@@ -25,19 +25,19 @@ def dict_dumper(provider):
     """
     ret = []
     for stuff in provider.get_all():
-        c = provider.get_by_id(stuff["id"])
+        concept_or_collection = provider.get_by_id(stuff["id"])
         labels = []
-        for label in c.labels:
-            ldict = {
+        for label in concept_or_collection.labels:
+            label_dict = {
                 "language": label.language,
                 "type": label.type,
                 "label": label.label,
             }
             if label.uri:
-                ldict["uri"] = label.uri
+                label_dict["uri"] = label.uri
                 if len(label.label_types):
-                    ldict["label_types"] = label.label_types
-            labels.append(ldict)
+                    label_dict["label_types"] = label.label_types
+            labels.append(label_dict)
         notes = [
             {
                 "note": note.note,
@@ -45,42 +45,42 @@ def dict_dumper(provider):
                 "language": note.language,
                 "markup": note.markup,
             }
-            for note in c.notes
+            for note in concept_or_collection.notes
         ]
         sources = [
             {"citation": source.citation, "markup": source.markup}
-            for source in c.sources
+            for source in concept_or_collection.sources
         ]
-        if isinstance(c, Concept):
+        if isinstance(concept_or_collection, Concept):
             ret.append(
                 {
-                    "id": c.id,
-                    "uri": c.uri,
-                    "type": c.type,
+                    "id": concept_or_collection.id,
+                    "uri": concept_or_collection.uri,
+                    "type": concept_or_collection.type,
                     "labels": labels,
                     "notes": notes,
                     "sources": sources,
-                    "narrower": c.narrower,
-                    "broader": c.broader,
-                    "related": c.related,
-                    "member_of": c.member_of,
-                    "subordinate_arrays": c.subordinate_arrays,
-                    "matches": c.matches,
+                    "narrower": concept_or_collection.narrower,
+                    "broader": concept_or_collection.broader,
+                    "related": concept_or_collection.related,
+                    "member_of": concept_or_collection.member_of,
+                    "subordinate_arrays": concept_or_collection.subordinate_arrays,
+                    "matches": concept_or_collection.matches,
                 }
             )
-        elif isinstance(c, Collection):
+        elif isinstance(concept_or_collection, Collection):
             ret.append(
                 {
-                    "id": c.id,
-                    "uri": c.uri,
-                    "type": c.type,
+                    "id": concept_or_collection.id,
+                    "uri": concept_or_collection.uri,
+                    "type": concept_or_collection.type,
                     "labels": labels,
                     "notes": notes,
                     "sources": sources,
-                    "members": c.members,
-                    "member_of": c.member_of,
-                    "superordinates": c.superordinates,
-                    "infer_concept_relations": c.infer_concept_relations,
+                    "members": concept_or_collection.members,
+                    "member_of": concept_or_collection.member_of,
+                    "superordinates": concept_or_collection.superordinates,
+                    "infer_concept_relations": concept_or_collection.infer_concept_relations,  # NoQa: B950
                 }
             )
     return ret

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -555,28 +555,28 @@ class TestTreesDictionaryProvider:
         assert la_chataigne in trees.get_all(language="fr")
 
     def test_find_all(self):
-        c = trees.find({"type": "all"})
-        assert 3 == len(c)
+        concepts = trees.find({"type": "all"})
+        assert 3 == len(concepts)
 
     def test_find_all_sort(self):
-        c = trees.find({"type": "all"}, sort="id", sort_order="desc")
-        assert [3, "2", "1"] == [cc["id"] for cc in c]
-        c = trees.find({"type": "all"}, sort="sortlabel", sort_order="asc")
-        assert [3, "1", "2"] == [cc["id"] for cc in c]
-        c = trees.find({"type": "all"}, sort="sortlabel", sort_order="desc")
-        assert ["2", "1", 3] == [cc["id"] for cc in c]
+        concepts = trees.find({"type": "all"}, sort="id", sort_order="desc")
+        assert [3, "2", "1"] == [concept["id"] for concept in concepts]
+        concepts = trees.find({"type": "all"}, sort="sortlabel", sort_order="asc")
+        assert [3, "1", "2"] == [concept["id"] for concept in concepts]
+        concepts = trees.find({"type": "all"}, sort="sortlabel", sort_order="desc")
+        assert ["2", "1", 3] == [concept["id"] for concept in concepts]
 
     def test_find_concepts(self):
-        c = trees.find({"type": "concept"})
-        assert 2 == len(c)
+        concepts = trees.find({"type": "concept"})
+        assert 2 == len(concepts)
 
     def test_find_collections(self):
-        c = trees.find({"type": "collection"})
-        assert 1 == len(c)
+        concepts = trees.find({"type": "collection"})
+        assert 1 == len(concepts)
 
     def test_find_type_None(self):
-        c = trees.find({"type": None})
-        assert len(c) == 3
+        concepts = trees.find({"type": None})
+        assert len(concepts) == 3
 
     def test_find_larch(self):
         assert trees.find({"label": "The Larch"}) == [
@@ -622,8 +622,8 @@ class TestTreesDictionaryProvider:
         assert len(concepts) == 1
 
     def test_find_empty_label(self):
-        c = trees.find({"label": ""})
-        assert 3 == len(c)
+        concepts = trees.find({"label": ""})
+        assert 3 == len(concepts)
 
     def test_find_lar(self):
         assert trees.find({"label": "lar"}) == [
@@ -636,39 +636,39 @@ class TestTreesDictionaryProvider:
         ]
 
     def test_find_es(self):
-        c = trees.find({"label": "es"})
-        assert 2 == len(c)
+        concepts = trees.find({"label": "es"})
+        assert 2 == len(concepts)
 
     def test_find_all_es(self):
-        c = trees.find({"label": "es", "type": "all"})
-        assert 2 == len(c)
+        concepts = trees.find({"label": "es", "type": "all"})
+        assert 2 == len(concepts)
 
     def test_find_concepts_es(self):
-        c = trees.find({"label": "es", "type": "concept"})
-        assert 1 == len(c)
-        for cc in c:
-            assert isinstance(trees.get_by_id(cc["id"]), Concept)
+        concepts = trees.find({"label": "es", "type": "concept"})
+        assert 1 == len(concepts)
+        for concept in concepts:
+            assert isinstance(trees.get_by_id(concept["id"]), Concept)
 
     def test_find_collections_es(self):
-        c = trees.find({"label": "es", "type": "collection"})
-        assert 1 == len(c)
-        for cc in c:
-            assert isinstance(trees.get_by_id(cc["id"]), Collection)
+        concepts = trees.find({"label": "es", "type": "collection"})
+        assert 1 == len(concepts)
+        for concept in concepts:
+            assert isinstance(trees.get_by_id(concept["id"]), Collection)
 
     def test_find_no_arguments(self):
         assert trees.find({}) == trees.get_all()
 
     def test_find_in_collection(self):
-        c = trees.find({"collection": {"id": 3}})
-        assert 2 == len(c)
-        for cc in c:
-            assert isinstance(trees.get_by_id(cc["id"]), Concept)
+        concepts = trees.find({"collection": {"id": 3}})
+        assert 2 == len(concepts)
+        for concept in concepts:
+            assert isinstance(trees.get_by_id(concept["id"]), Concept)
 
     def test_find_in_collection_es(self):
-        c = trees.find({"collection": {"id": 3}, "label": "es"})
-        assert 1 == len(c)
-        for cc in c:
-            assert isinstance(trees.get_by_id(cc["id"]), Concept)
+        concepts = trees.find({"collection": {"id": 3}, "label": "es"})
+        assert 1 == len(concepts)
+        for concept in concepts:
+            assert isinstance(trees.get_by_id(concept["id"]), Concept)
 
     def test_find_in_unexisting_collection(self):
         with pytest.raises(ValueError):
@@ -708,7 +708,7 @@ class TestTreesDictionaryProvider:
         assert 1 == len(concepts)
 
     def test_find_matches_uri_and_type_inheritance_present(self):
-        c = trees.find(
+        concepts = trees.find(
             {
                 "matches": {
                     "uri": "http://id.python.org/different/"
@@ -717,10 +717,10 @@ class TestTreesDictionaryProvider:
                 }
             }
         )
-        assert 1 == len(c)
+        assert 1 == len(concepts)
 
     def test_find_matches_uri_and_wrong_type(self):
-        c = trees.find(
+        concepts = trees.find(
             {
                 "matches": {
                     "uri": "http://id.python.org/different/"
@@ -729,7 +729,7 @@ class TestTreesDictionaryProvider:
                 }
             }
         )
-        assert 0 == len(c)
+        assert 0 == len(concepts)
 
     def test_get_display_top(self):
         top = trees.get_top_display()
@@ -871,22 +871,24 @@ class TestGeoDictionaryProvider:
         assert {4, 7, 8, 9, 16} == set(geo.expand(333))
 
     def test_find_in_collection(self):
-        c = geo.find({"collection": {"id": 333}})
-        assert 3 == len(c)
-        for cc in c:
-            assert isinstance(geo.get_by_id(cc["id"]), Concept)
+        concepts = geo.find({"collection": {"id": 333}})
+        assert 3 == len(concepts)
+        for concept in concepts:
+            assert isinstance(geo.get_by_id(concept["id"]), Concept)
 
     def test_find_in_collection_depth_all(self):
-        c = geo.find({"collection": {"id": 333, "depth": "all"}})
-        assert 5 == len(c)
-        for cc in c:
-            assert isinstance(geo.get_by_id(cc["id"]), Concept)
+        concepts = geo.find({"collection": {"id": 333, "depth": "all"}})
+        assert 5 == len(concepts)
+        for concept in concepts:
+            assert isinstance(geo.get_by_id(concept["id"]), Concept)
 
     def test_find_in_collection_depth_all_wallon(self):
-        c = geo.find({"collection": {"id": "333", "depth": "all"}, "label": "Wallon"})
-        assert 1 == len(c)
-        for cc in c:
-            assert isinstance(geo.get_by_id(cc["id"]), Concept)
+        concepts = geo.find(
+            {"collection": {"id": "333", "depth": "all"}, "label": "Wallon"}
+        )
+        assert 1 == len(concepts)
+        for concept in concepts:
+            assert isinstance(geo.get_by_id(concept["id"]), Concept)
 
     def test_get_display_top(self):
         top = geo.get_top_display()
@@ -986,34 +988,34 @@ class TestSimpleCsvProvider:
         assert 11 == len(csv_provider.get_all())
 
     def test_get_egg_and_bacon(self, csv_provider):
-        eb = csv_provider.get_by_id(1)
-        assert isinstance(eb, Concept)
-        assert "1" == eb.id
-        assert "http://id.python.org/menu/1" == eb.uri
-        assert "Egg and Bacon" == eb.label().label
-        assert "prefLabel" == eb.label().type
-        assert [] == eb.notes
-        assert 1 == len(eb.sources)
-        assert "Monthy Python, Episode Twenty-five." == eb.sources[0].citation
+        concept = csv_provider.get_by_id(1)
+        assert isinstance(concept, Concept)
+        assert "1" == concept.id
+        assert "http://id.python.org/menu/1" == concept.uri
+        assert "Egg and Bacon" == concept.label().label
+        assert "prefLabel" == concept.label().type
+        assert [] == concept.notes
+        assert 1 == len(concept.sources)
+        assert "Monthy Python, Episode Twenty-five." == concept.sources[0].citation
 
     def test_get_egg_and_spam_by_uri(self, csv_provider):
-        eb = csv_provider.get_by_uri("http://id.python.org/menu/3")
-        assert isinstance(eb, Concept)
-        assert "3" == eb.id
-        assert "http://id.python.org/menu/3" == eb.uri
+        concept = csv_provider.get_by_uri("http://id.python.org/menu/3")
+        assert isinstance(concept, Concept)
+        assert "3" == concept.id
+        assert "http://id.python.org/menu/3" == concept.uri
 
     def test_find_spam(self, csv_provider):
         spam = csv_provider.find({"label": "Spam"})
         assert 8 == len(spam)
 
     def test_get_lobster(self, csv_provider):
-        eb = csv_provider.get_by_id(11)
-        assert isinstance(eb, Concept)
-        assert "11" == eb.id
-        assert "Lobster Thermidor" == eb.label().label
-        assert isinstance(eb.notes[0], Note)
-        assert "Mornay" in eb.notes[0].note
-        assert "note" == eb.notes[0].type
+        concept = csv_provider.get_by_id(11)
+        assert isinstance(concept, Concept)
+        assert "11" == concept.id
+        assert "Lobster Thermidor" == concept.label().label
+        assert isinstance(concept.notes[0], Note)
+        assert "Mornay" in concept.notes[0].note
+        assert "note" == concept.notes[0].type
 
     def test_find_sausage_case_insensitive(self, csv_provider):
         sausages = csv_provider.find({"label": "sausage"})

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -71,14 +71,14 @@ class TestRegistry:
         from skosprovider.skos import ConceptScheme
         from skosprovider.providers import DictionaryProvider
 
-        t = DictionaryProvider(
+        provider = DictionaryProvider(
             {"id": "TREES", "default_language": "nl"},
             [larch, chestnut, species],
             concept_scheme=ConceptScheme("urn:something"),
             allowed_instance_scopes=["threaded_thread"],
         )
         with pytest.raises(RegistryException):
-            registry.register_provider(t)
+            registry.register_provider(provider)
 
     def test_one_provider_removeProvider(self, registry, trees_provider):
         registry.register_provider(trees_provider)
@@ -140,28 +140,28 @@ class TestRegistry:
 
     def test_one_provider_getConceptByUri(self, registry, trees_provider):
         registry.register_provider(trees_provider)
-        c = registry.get_by_uri("http://id.trees.org/1")
-        assert c.id == "1"
-        assert c.uri == "http://id.trees.org/1"
+        concept_or_collection = registry.get_by_uri("http://id.trees.org/1")
+        assert concept_or_collection.id == "1"
+        assert concept_or_collection.uri == "http://id.trees.org/1"
 
     def test_one_provider_getConceptByUriDifferentFromConceptScheme(self, registry):
         from skosprovider.skos import ConceptScheme
         from skosprovider.providers import DictionaryProvider
 
-        t = DictionaryProvider(
+        provider = DictionaryProvider(
             {"id": "TREES", "default_language": "nl"},
             [larch, chestnut, species],
             concept_scheme=ConceptScheme("urn:something"),
         )
-        registry.register_provider(t)
-        c = registry.get_by_uri("http://id.trees.org/1")
-        assert c.id == "1"
-        assert c.uri == "http://id.trees.org/1"
+        registry.register_provider(provider)
+        concept_or_collection = registry.get_by_uri("http://id.trees.org/1")
+        assert concept_or_collection.id == "1"
+        assert concept_or_collection.uri == "http://id.trees.org/1"
 
     def test_one_provider_getConceptByUnexistingUri(self, registry, trees_provider):
         registry.register_provider(trees_provider)
-        c = registry.get_by_uri("http://id.thingy.com/123456")
-        assert not c
+        concept_or_collection = registry.get_by_uri("http://id.thingy.com/123456")
+        assert not concept_or_collection
 
     def test_get_by_invalid_uri(self, registry):
         with pytest.raises(ValueError):
@@ -264,25 +264,40 @@ class TestRegistry:
 
     def test_one_provider_findConceptsWithSubject(self, registry, trees_provider):
         registry.register_provider(trees_provider)
-        provs = registry.get_providers(subject="biology")
-        res = [{"id": p.get_vocabulary_id(), "concepts": p.find({})} for p in provs]
-        assert res == registry.find({}, subject="biology")
+        providers = registry.get_providers(subject="biology")
+        expected = [
+            {
+                "id": provider.get_vocabulary_id(),
+                "concepts": provider.find({}),
+            }
+            for provider in providers
+        ]
+        assert expected == registry.find({}, subject="biology")
 
     def test_one_provider_findConceptsWithSubject_language_en(
         self, registry, trees_provider
     ):
         registry.register_provider(trees_provider)
-        provs = registry.get_providers(subject="biology")
-        res = [
-            {"id": p.get_vocabulary_id(), "concepts": p.find({}, language="en")}
-            for p in provs
+        providers = registry.get_providers(subject="biology")
+        expected = [
+            {
+                "id": provider.get_vocabulary_id(),
+                "concepts": provider.find({}, language="en"),
+            }
+            for provider in providers
         ]
-        assert res == registry.find({}, subject="biology", language="en")
+        assert expected == registry.find({}, subject="biology", language="en")
 
     def test_one_provider_findConceptsWithSubject_language_nl(
         self, registry, trees_provider
     ):
         registry.register_provider(trees_provider)
-        provs = registry.get_providers(subject="biology")
-        res = [{"id": p.get_vocabulary_id(), "concepts": p.find({})} for p in provs]
-        assert res == registry.find({}, subject="biology", language="nl")
+        providers = registry.get_providers(subject="biology")
+        expected = [
+            {
+                "id": provider.get_vocabulary_id(),
+                "concepts": provider.find({}),
+            }
+            for provider in providers
+        ]
+        assert expected == registry.find({}, subject="biology", language="nl")

--- a/tests/test_skos.py
+++ b/tests/test_skos.py
@@ -300,60 +300,60 @@ class TestConcept:
         assert "Concept('1')" == repr(concept)
 
     def test_in(self):
-        c = Concept(1)
-        assert hasattr(c, "id")
-        assert hasattr(c, "uri")
-        assert hasattr(c, "labels")
-        assert hasattr(c, "notes")
-        assert hasattr(c, "broader")
-        assert hasattr(c, "narrower")
-        assert hasattr(c, "related")
-        assert hasattr(c, "member_of")
+        concept = Concept(1)
+        assert hasattr(concept, "id")
+        assert hasattr(concept, "uri")
+        assert hasattr(concept, "labels")
+        assert hasattr(concept, "notes")
+        assert hasattr(concept, "broader")
+        assert hasattr(concept, "narrower")
+        assert hasattr(concept, "related")
+        assert hasattr(concept, "member_of")
 
     def test_label(self):
         labels = self._get_labels()
-        c = Concept(1, labels=labels)
-        assert label(labels) == c.label()
-        assert label(labels, "nl") == c.label("nl")
-        assert label(labels, "en") == c.label("en")
-        assert label(labels, None) == c.label(None)
+        concept = Concept(1, labels=labels)
+        assert label(labels) == concept.label()
+        assert label(labels, "nl") == concept.label("nl")
+        assert label(labels, "en") == concept.label("en")
+        assert label(labels, None) == concept.label(None)
 
     def test_sort_key(self):
         labels = self._get_labels()
-        sl = Label("allereerste", type="sortLabel", language="nl-BE")
-        labels.append(sl)
-        c = Concept(1, labels=labels)
-        assert "allereerste" == c._sortkey("sortlabel")
-        assert "allereerste" == c._sortkey("sortlabel", "nl")
-        assert "knocke-heyst" == c._sortkey("sortlabel", "en")
-        assert "" == c._sortkey("uri")
+        sort_label = Label("allereerste", type="sortLabel", language="nl-BE")
+        labels.append(sort_label)
+        concept = Concept(1, labels=labels)
+        assert "allereerste" == concept._sortkey("sortlabel")
+        assert "allereerste" == concept._sortkey("sortlabel", "nl")
+        assert "knocke-heyst" == concept._sortkey("sortlabel", "en")
+        assert "" == concept._sortkey("uri")
 
     def test_uri(self):
-        c = Concept(1, uri="urn:x-skosprovider:gemeenten:1")
-        assert 1 == c.id
-        assert "urn:x-skosprovider:gemeenten:1" == c.uri
+        concept = Concept(1, uri="urn:x-skosprovider:gemeenten:1")
+        assert 1 == concept.id
+        assert "urn:x-skosprovider:gemeenten:1" == concept.uri
 
     def test_member_of(self):
-        c = Concept(1, uri="urn:x-skosprovider:gemeenten:1", member_of=[15])
-        assert {15} == set(c.member_of)
+        concept = Concept(1, uri="urn:x-skosprovider:gemeenten:1", member_of=[15])
+        assert {15} == set(concept.member_of)
 
     def test_matches(self):
-        c = Concept(
+        concept = Concept(
             1,
             uri="urn:x-skosprovider:gemeenten:1",
             matches={"broad": ["http://id.something.org/provincies/1"]},
         )
-        assert "close" in c.matches
-        assert "exact" in c.matches
-        assert "broad" in c.matches
-        assert "narrow" in c.matches
-        assert "related" in c.matches
-        assert ["http://id.something.org/provincies/1"] == c.matches["broad"]
+        assert "close" in concept.matches
+        assert "exact" in concept.matches
+        assert "broad" in concept.matches
+        assert "narrow" in concept.matches
+        assert "related" in concept.matches
+        assert ["http://id.something.org/provincies/1"] == concept.matches["broad"]
 
     def test_source(self):
-        c = Concept(id=1, sources=[{"citation": "My citation"}])
-        assert 1 == len(c.sources)
-        assert "My citation" == c.sources[0].citation
+        concept = Concept(id=1, sources=[{"citation": "My citation"}])
+        assert 1 == len(concept.sources)
+        assert "My citation" == concept.sources[0].citation
 
 
 class TestCollection:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -173,16 +173,16 @@ class TestDictDumper:
         ]
 
     def test_empty_tree_provider(self):
-        pv = self._get_tree_provider([])
-        assert [] == dict_dumper(pv)
+        provider = self._get_tree_provider([])
+        assert [] == dict_dumper(provider)
 
     def test_tree_provider(self, world_dump):
         dump = dict_dumper(geo)
         assert isinstance(dump, list)
-        for c in dump:
-            assert isinstance(c, dict)
-            assert "type" in c
-            assert "id" in c
+        for concept_or_collection in dump:
+            assert isinstance(concept_or_collection, dict)
+            assert "type" in concept_or_collection
+            assert "id" in concept_or_collection
         assert world_dump in dump
 
     def test_flat_provider_round_trip(self):


### PR DESCRIPTION
fixes #164 only 1 line became to long so i would keep concept_or_collection for c

## Variable renames

| Original | Renamed to | Context |
|---|---|---|
| `c` | `concept_or_collection` | Concept or Collection (primary rename — per team poll) |
| `c` | `concept` | in tests where `c` held a single Concept |
| `c` | `concepts` | in tests where `c` held a list of `find()` results |
| `cc` | `concept` | iteration var over `find()` results |
| `cs` | `concept_scheme` | ConceptScheme |
| `cs_uri` / `csuri` / `csuris` | `concept_scheme_uri` / `concept_scheme_uris` | |
| `coll` | `collection` | Collection |
| `collid` | `collection_id` | |
| `cid` | `narrower_id` | narrower concept id |
| `dcid` | `display_child_id` | |
| `dc` | `display_children_list` | |
| `co` | `child` | display child concept |
| `td` | `top_display` | top-level display list |
| `p` | `provider` | VocabularyProvider |
| `pv` | `provider` | |
| `provs` | `providers` | |
| `pargs` | `provider_args` | |
| `k` | `provider_id` | provider dict key |
| `m` | `member` / `member_id` | Collection member |
| `mt` | `matchtype` | SKOS match type |
| `n` | `note` | Note |
| `s` | `source` | Source |
| `relc` | `related_concept` | |
| `t` | `provider` | in `test_registry.py` |
| `eb` | `concept` | was "egg and bacon" |
| `sl` | `sort_label` | |
| `ldict` | `label_dict` | |
| `ltypemap` | `label_type_map` | |
| `ntypemap` | `note_type_map` | |
| `lbl_renderer` / `nt_renderer` / `s_renderer` | `label_renderer` / `note_renderer` / `source_renderer` | inner renderer fns |
| `res` | `expected` | expected test value |