### PR TITLE
Integrate RDF provider

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -44,3 +44,15 @@ Utils module
 
 .. automodule:: skosprovider.utils
    :members:
+
+RDF Providers module
+--------------------
+
+.. automodule:: skosprovider.rdf.providers
+   :members:
+
+RDF Utils module
+----------------
+
+.. automodule:: skosprovider.rdf.utils
+   :members:

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -37,12 +37,13 @@ Currently the following other providers exist:
   :class:`VocabularyProvider <skosprovider.providers.VocabularyProvider>` 
   interface with a `SQLAlchemy <http://www.sqlalchemy.org>`_ backend. This allows
   using a RDBMS for reading, but also writing, :term:`SKOS` concepts.
-* `Skosprovider_rdf <http://skosprovider-rdf.readthedocs.org/en/latest/>`_:
-  An implementation of the 
-  :class:`VocabularyProvider <skosprovider.providers.VocabularyProvider>` 
-  interface with a `RDFLib <https://rdflib.readthedocs.org/en/latest/>`_ 
-  backend. This allows using a SKOS RDF file as the source for a provider, 
-  but also dumping a skosprovider to a SKOS RDF file.
+* :mod:`skosprovider.rdf`:
+  An implementation of the
+  :class:`VocabularyProvider <skosprovider.providers.VocabularyProvider>`
+  interface with a `RDFLib <https://rdflib.readthedocs.org/en/latest/>`_
+  backend. This allows using a SKOS RDF file as the source for a provider,
+  but also dumping a skosprovider to a SKOS RDF file. Install with
+  ``pip install skosprovider[rdf]``.
 * `Skosprovider_atramhasis <https://skosprovider-atramhasis.readthedocs.org>`_:
   The :class:`AtramhasisProvider <skosprovider.providers.AtramhasisProvider>` 
   lets you interact with an Atramhasis_ instance. 

--- a/examples/rdf/data/menu.csv
+++ b/examples/rdf/data/menu.csv
@@ -1,0 +1,11 @@
+1,"Egg and Bacon",
+2,"Egg, sausage and Bacon",
+3,"Egg and Spam",
+4,"Spam Egg Sausage and Spam",
+5,"Egg, Bacon and Spam",
+6,"Egg, Bacon, sausage and Spam",
+7,"Spam, Bacon, sausage and Spam",
+8,"Spam, Egg, Spam, Spam, Bacon and Spam",
+9,"Spam, Spam, Spam, Egg and Spam",
+10,"Spam, Spam, Spam, Spam, Spam, Spam, Spam, baked beans, Spam, Spam, Spam and Spam",
+11,"Lobster Thermidor", "Lobster Thermidor aux crevettes with a Mornay sauce, served in a Provencale manner with shallots and aubergines, garnished with truffle pâté, brandy and a fried egg on top and Spam"

--- a/examples/rdf/dump.py
+++ b/examples/rdf/dump.py
@@ -1,0 +1,49 @@
+'''
+This script demonstrates dumping a
+:class:`skosprovider.providers.SimpleCsvProvider` as a RDF Graph. In this
+case, `n3` serialisation is used, other serialisations are available through
+:mod:`rdflib`.
+'''
+>
+import os
+import csv
+
+from skosprovider.providers import SimpleCsvProvider
+
+from skosprovider.uri import UriPatternGenerator
+
+from skosprovider.skos import ConceptScheme, Label, Note, Source
+
+from skosprovider.rdf.utils import rdf_dumper
+
+ifile = open(
+    os.path.join(os.path.dirname(__file__), 'data', 'menu.csv'))
+
+reader = csv.reader(ifile)
+
+csvprovider = SimpleCsvProvider(
+    {'id': 'MENU'},
+    reader,
+    uri_generator=UriPatternGenerator('http://id.python.org/menu/%s'),
+    concept_scheme=ConceptScheme(
+        uri='http://id.python.org/menu',
+        labels=[
+            Label(type='prefLabel', language='en', label='A pythonesque menu.')
+        ],
+        notes=[
+            Note(
+                type='changeNote',
+                language='en',
+                note="<strong>We didn't need no change notes when I was younger.</strong>",
+                markup='HTML'
+            )
+        ],
+        sources=[
+            Source("Monthy Python's Flying Circus, 1970. Spam.")
+        ]
+    )
+)
+
+graph = rdf_dumper(csvprovider)
+
+print(graph.serialize(format='n3'))

--- a/examples/rdf/dump_extra_data.py
+++ b/examples/rdf/dump_extra_data.py
@@ -1,0 +1,97 @@
+"""
+This script demonstrates how :class:`~skosprovider.rdf.providers.RDFProvider`
+captures unknown RDF predicates as ``extra_data`` and how
+:func:`~skosprovider.rdf.utils.rdf_dumper` can round-trip them back via a
+custom :data:`~skosprovider.rdf.utils.RdfSerializer`.
+
+The input graph contains a ``skos:notation`` triple for the larch concept.
+``skos:notation`` is not a predicate the provider extracts explicitly, so it
+ends up in ``extra_data`` as a sub-graph.  The serializer re-injects those
+triples when dumping so no information is lost.
+"""
+
+import rdflib
+from rdflib import Graph
+from rdflib import Literal
+from rdflib.namespace import DCTERMS
+from rdflib.namespace import RDF
+from rdflib.namespace import SKOS
+from rdflib.term import URIRef
+
+from skosprovider.rdf.providers import RDFProvider
+from skosprovider.rdf.utils import rdf_dumper
+
+# Build an RDF graph by hand, including a skos:notation triple that the
+# provider does not handle natively.
+source_graph = Graph()
+source_graph.namespace_manager.bind("skos", SKOS)
+source_graph.namespace_manager.bind("dcterms", DCTERMS)
+
+CS = URIRef("http://id.trees.org")
+LARCH = URIRef("http://id.trees.org/1")
+CHESTNUT = URIRef("http://id.trees.org/2")
+SPECIES = URIRef("http://id.trees.org/3")
+
+source_graph.add((CS, RDF.type, SKOS.ConceptScheme))
+source_graph.add((CS, DCTERMS.identifier, Literal("TREES")))
+source_graph.add((CS, SKOS.prefLabel, Literal("Trees", lang="en")))
+source_graph.add((CS, SKOS.prefLabel, Literal("Bomen", lang="nl")))
+
+source_graph.add((LARCH, RDF.type, SKOS.Concept))
+source_graph.add((LARCH, SKOS.inScheme, CS))
+source_graph.add((LARCH, DCTERMS.identifier, Literal("1")))
+source_graph.add((LARCH, SKOS.prefLabel, Literal("The Larch", lang="en")))
+source_graph.add((LARCH, SKOS.prefLabel, Literal("De Lariks", lang="nl")))
+source_graph.add((LARCH, SKOS.definition, Literal("A type of tree.", lang="en")))
+source_graph.add((LARCH, SKOS.notation, Literal("larch-001")))  # extra predicate
+
+source_graph.add((CHESTNUT, RDF.type, SKOS.Concept))
+source_graph.add((CHESTNUT, SKOS.inScheme, CS))
+source_graph.add((CHESTNUT, DCTERMS.identifier, Literal("2")))
+source_graph.add((CHESTNUT, SKOS.prefLabel, Literal("The Chestnut", lang="en")))
+source_graph.add((CHESTNUT, SKOS.altLabel, Literal("De Paardekastanje", lang="nl")))
+source_graph.add((CHESTNUT, SKOS.definition, Literal("A different type of tree.", lang="en")))
+
+source_graph.add((SPECIES, RDF.type, SKOS.Collection))
+source_graph.add((SPECIES, SKOS.inScheme, CS))
+source_graph.add((SPECIES, DCTERMS.identifier, Literal("3")))
+source_graph.add((SPECIES, SKOS.prefLabel, Literal("Trees by species", lang="en")))
+source_graph.add((SPECIES, SKOS.prefLabel, Literal("Bomen per soort", lang="nl")))
+source_graph.add((SPECIES, SKOS.member, LARCH))
+source_graph.add((SPECIES, SKOS.member, CHESTNUT))
+
+# --- Load via RDFProvider ---
+# skos:notation is not in _KNOWN_CONCEPT_PREDICATES, so it lands in
+# extra_data as a sub-graph containing the leftover triple(s).
+provider = RDFProvider({"id": "TREES"}, source_graph)
+
+larch = provider.get_by_uri("http://id.trees.org/1")
+msg = "Larch extra_data (sub-graph with skos:notation)"
+print(msg)
+print(len(msg) * "=")
+if larch.extra_data is not None:
+    print(larch.extra_data.serialize(format="n3"))
+else:
+    print("None")
+
+chestnut = provider.get_by_uri("http://id.trees.org/2")
+msg = "Chestnut extra_data (no unknown predicates → None)"
+print(msg)
+print(len(msg) * "=")
+print(chestnut.extra_data)
+
+
+def extra_data_rdf_serializer(graph: Graph, subject: URIRef, obj) -> None:
+    """Re-inject the extra_data sub-graph triples into the output graph."""
+    if not isinstance(obj.extra_data, rdflib.Graph):
+        return
+    for s, p, o in obj.extra_data.triples((subject, None, None)):
+        graph.add((s, p, o))
+
+
+# --- Dump back, re-injecting extra_data triples ---
+dumped = rdf_dumper(provider, extra_data_serializer=extra_data_rdf_serializer)
+msg = "Round-tripped graph (skos:notation preserved)"
+print(msg)
+print(len(msg) * "=")
+print(dumped.serialize(format="n3"))

--- a/examples/rdf/load_skos.py
+++ b/examples/rdf/load_skos.py
@@ -1,0 +1,70 @@
+import json
+import os
+
+import rdflib
+from rdflib import Graph
+from skosprovider.jsonld import jsonld_dumper
+from skosprovider.rdf.providers import RDFProvider
+
+graph = Graph()
+
+file = os.path.join(
+    os.path.dirname(__file__), "..", "..", "tests", "data", "simple_turtle_products"
+)
+graph.parse(file, format="turtle")
+
+provider = RDFProvider({"id": "PRODUCTS"}, graph)
+
+print("provider.get_all()")
+print("------------------")
+print(provider.get_all())
+print("")
+
+print("provider.find({'label': 'jewelry'})")
+print("-----------------------------------")
+print(provider.find({"label": "jewelry"}))
+print("")
+
+
+print("provider.get_by_id('http://wwww.products.com/Jewellery')")
+print("--------------------------------------------------------")
+print(provider.get_by_id("http://www.products.com/Jewellery"))
+print("")
+
+print("provider.get_by_uri('http://wwww.products.com/Jewellery')")
+print("---------------------------------------------------------")
+print(provider.get_by_uri("http://www.products.com/Jewellery"))
+print("")
+
+print("extra_data per concept/collection")
+print("----------------------------------")
+for item in provider.get_all():
+    obj = provider.get_by_uri(item["uri"])
+    if obj is False:
+        continue
+
+    if obj.extra_data is not None:
+        print(f"{item['uri']}:")
+        print(obj.extra_data.serialize(format="n3"))
+    else:
+        print(f"{item['uri']}: no extra_data")
+
+    print("=======")
+
+
+def extra_data_serializer(obj):
+    """Convert extra_data sub-graph to a dict of JSON-LD properties."""
+    if not isinstance(obj.extra_data, rdflib.Graph):
+        return None
+    nodes = json.loads(obj.extra_data.serialize(format="json-ld"))
+    for node in nodes:
+        if node.get("@id") == obj.uri:
+            result = {k: v for k, v in node.items() if k != "@id"}
+            return result or None
+    return None
+
+
+print("jsonld_dumper with extra_data")
+print("------------------------------")
+doc = jsonld_dumper(provider, extra_data_serializer=extra_data_serializer)
+print(json.dumps(doc, indent=2))

--- a/examples/rdf/load_specific_scheme.py
+++ b/examples/rdf/load_specific_scheme.py
@@ -1,0 +1,41 @@
+'''
+This examples fetches only one conceptscheme from a turtle file containing two.
+'''
+
+import os
+
+from rdflib import Graph
+
+from skosprovider.rdf.providers import RDFProvider
+
+graph = Graph()
+
+file = os.path.join(os.path.dirname(__file__), '..', '..', 'tests', 'data', 'waarde_en_besluit_types.ttl')
+graph.parse(file, format="turtle")
+
+provider = RDFProvider(
+    {'id': 'WAARDETYPES'},
+    graph,
+    concept_scheme_uri = 'https://id.erfgoed.net/thesauri/waardetypes'
+)
+
+print("provider.get_all()")
+print("------------------")
+print(provider.get_all())
+print("")
+
+print("provider.find({'label': 'esthetische waarde'})")
+print("-----------------------------------")
+print(provider.find({'label': 'esthetische waarde'}))
+print("")
+
+
+print("provider.get_by_id(46)")
+print("--------------------------------------------------------")
+print(provider.get_by_id('46'))
+print("")
+
+print("provider.get_by_uri('https://id.erfgoed.net/thesauri/waardetypes/46')")
+print("---------------------------------------------------------")
+print(provider.get_by_uri('https://id.erfgoed.net/thesauri/waardetypes/46'))
+print("")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,9 @@ Source = "https://github.com/OnroerendErfgoed/skosprovider"
 Documentation = "https://skosprovider.readthedocs.io/en/latest/"
 
 [project.optional-dependencies]
+rdf = [
+    "rdflib[html]>=7.0.0",
+]
 dev = [
     # Linting and formatting
     "flake8>=7.1.2",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -38,6 +38,8 @@ flake8-import-order==0.19.2
     # via skosprovider (pyproject.toml)
 frozendict==2.4.7
     # via pyld
+html5rdf==1.2.1
+    # via rdflib
 identify==2.6.18
     # via pre-commit
 idna==3.11
@@ -90,6 +92,8 @@ pygments==2.20.0
     #   sphinx
 pyld==2.0.3
     # via skosprovider (pyproject.toml)
+pyparsing==3.3.2
+    # via rdflib
 pytest==8.4.2
     # via
     #   skosprovider (pyproject.toml)
@@ -102,6 +106,8 @@ pytokens==0.4.1
     # via black
 pyyaml==6.0.3
     # via pre-commit
+rdflib==7.6.0
+    # via skosprovider (pyproject.toml)
 requests==2.33.1
     # via sphinx
 rfc3987==1.3.8

--- a/scripts/compile_requirements.sh
+++ b/scripts/compile_requirements.sh
@@ -11,7 +11,7 @@ uv pip compile $PIP_COMPILE_ARGS -o "$SCRIPT_DIR/../requirements.txt" pyproject.
 echo " └Done"
 
 echo "Compiling requirements-dev.txt..."
-uv pip compile $PIP_COMPILE_ARGS --extra dev -o "$SCRIPT_DIR/../requirements-dev.txt" pyproject.toml
+uv pip compile $PIP_COMPILE_ARGS --all-extras -o "$SCRIPT_DIR/../requirements-dev.txt" pyproject.toml
 echo " └Done"
 
 cd -

--- a/skosprovider/exceptions.py
+++ b/skosprovider/exceptions.py
@@ -1,21 +1,21 @@
-'''This module provides custom exceptions for skos providers.
+"""This module provides custom exceptions for skos providers.
 
 .. versionadded:: 0.5.0
-'''
+"""
 
 
 class ProviderUnavailableException(Exception):
-    '''
+    """
     This exception can be raised by a provider if it's unable to provide
     the thesaurus. This can occur when an underlying resource is unavailable
     (database connection, webservice, ...). The message should contain some
     more information about the problem.
-    '''
+    """
 
     def __init__(self, message):
-        '''
+        """
         :param message: More information about the exception.
-        '''
+        """
         self.message = message
 
     def __repr__(self):

--- a/skosprovider/providers.py
+++ b/skosprovider/providers.py
@@ -10,6 +10,8 @@ instance of a certain :class:`VocabularyProvider` will deal with concepts and
 collections from a single conceptscheme.
 """
 
+from __future__ import annotations
+
 import abc
 import copy
 import logging
@@ -669,23 +671,24 @@ class MemoryProvider(VocabularyProvider[ExtraData]):
     def expand(self, id: str | int) -> list[Any] | Literal[False]:
         id = str(id)
         for concept_or_collection in self.list:
-            if str(concept_or_collection.id) == id:
-                if isinstance(concept_or_collection, Concept):
-                    concept = concept_or_collection
-                    ret = {concept.id}
-                    for narrower_id in concept.narrower:
-                        ret |= set(self.expand(narrower_id))
-                    for collection_id in concept.subordinate_arrays:
-                        collection = self.get_by_id(collection_id)
-                        if collection.infer_concept_relations:
-                            ret |= set(self.expand(collection_id))
-                    return list(ret)
-                elif isinstance(concept_or_collection, Collection):
-                    collection = concept_or_collection
-                    ret = set()
-                    for member in collection.members:
-                        ret |= set(self.expand(member))
-                    return list(ret)
+            if str(concept_or_collection.id) != id:
+                continue
+            if isinstance(concept_or_collection, Concept):
+                concept = concept_or_collection
+                ret = {concept.id}
+                for narrower_id in concept.narrower:
+                    ret |= set(self.expand(narrower_id))
+                for collection_id in concept.subordinate_arrays:
+                    collection = self.get_by_id(collection_id)
+                    if collection.infer_concept_relations:
+                        ret |= set(self.expand(collection_id))
+                return list(ret)
+            elif isinstance(concept_or_collection, Collection):
+                collection = concept_or_collection
+                ret = set()
+                for member in collection.members:
+                    ret |= set(self.expand(member))
+                return list(ret)
         return False
 
     def get_top_display(self, **kwargs: Any) -> list[dict]:

--- a/skosprovider/rdf/providers.py
+++ b/skosprovider/rdf/providers.py
@@ -1,0 +1,398 @@
+"""
+This module contains an RDFProvider, an implementation of the
+:class:`skosprovider.providers.VocabularyProvider` interface that uses a
+:class:`rdflib.graph.Graph` as input.
+"""
+
+import logging
+
+import rdflib
+from language_tags import tags
+from rdflib.namespace import DC
+from rdflib.namespace import DCTERMS
+from rdflib.namespace import RDF
+from rdflib.namespace import SKOS
+from rdflib.namespace import VOID
+from rdflib.term import URIRef
+
+from skosprovider.providers import MemoryProvider
+from skosprovider.rdf.utils import text_
+from skosprovider.skos import Collection
+from skosprovider.skos import Concept
+from skosprovider.skos import ConceptScheme
+from skosprovider.skos import Label
+from skosprovider.skos import Note
+from skosprovider.skos import Source
+from skosprovider.uri import DefaultConceptSchemeUrnGenerator
+
+log = logging.getLogger(__name__)
+
+SKOS_THES = rdflib.Namespace("http://purl.org/iso25964/skos-thes#")
+
+def _skos_term(name: str) -> URIRef:
+    return URIRef("http://www.w3.org/2004/02/skos/core#" + name)
+
+
+_KNOWN_CONCEPT_PREDICATES: frozenset = frozenset(
+    [
+        RDF.type,
+        SKOS.inScheme,
+        SKOS.topConceptOf,
+        DCTERMS.identifier,
+        DC.identifier,
+        DCTERMS.source,
+        SKOS.broader,
+        SKOS.narrower,
+        SKOS.related,
+        SKOS_THES.subordinateArray,
+        VOID.inDataset,
+    ]
+    + [_skos_term(t) for t in Label.valid_types]
+    + [_skos_term(t) for t in Note.valid_types]
+    + [_skos_term(k + "Match") for k in Concept.matchtypes]
+)
+
+_KNOWN_COLLECTION_PREDICATES: frozenset = frozenset(
+    [
+        RDF.type,
+        SKOS.inScheme,
+        DCTERMS.identifier,
+        DC.identifier,
+        DCTERMS.source,
+        SKOS.member,
+        SKOS_THES.superOrdinate,
+        VOID.inDataset,
+    ]
+    + [_skos_term(t) for t in Label.valid_types]
+    + [_skos_term(t) for t in Note.valid_types]
+)
+
+_KNOWN_CONCEPTSCHEME_PREDICATES: frozenset = frozenset(
+    [
+        RDF.type,
+        DCTERMS.identifier,
+        DC.identifier,
+        DCTERMS.source,
+        DCTERMS.language,
+        DC.language,
+        SKOS.hasTopConcept,
+        VOID.inDataset,
+    ]
+    + [_skos_term(t) for t in Label.valid_types]
+    + [_skos_term(t) for t in Note.valid_types]
+)
+
+
+class RDFProvider(MemoryProvider[rdflib.Graph]):
+    """
+    Should the provider only take concepts into account explicitly linked
+    to the conceptscheme?
+    """
+
+    check_in_scheme = False
+
+    """
+    A simple vocabulary provider that use an :class:`rdflib.graph.Graph`
+    as input. The provider expects a RDF graph with elements that represent
+    the SKOS concepts and collections.
+
+    Please be aware that this provider needs to load the entire graph in memory.
+    """
+
+    def __init__(self, metadata, graph, **kwargs):
+        self.graph = graph
+        self.check_in_scheme = False
+        if not "concept_scheme" in kwargs:
+            kwargs["concept_scheme"] = self._cs_from_graph(metadata, **kwargs)
+        else:
+            self.check_in_scheme = True
+        super().__init__(metadata, [], **kwargs)
+        self.list = self._from_graph()
+
+    def _cs_from_graph(self, metadata, **kwargs):
+        cslist = []
+        for sub in self.graph.subjects(RDF.type, SKOS.ConceptScheme):
+            uri = self.to_text(sub)
+            cs = ConceptScheme(
+                uri=uri,
+                labels=self._create_from_subject_typelist(
+                    sub, self._scrub_label_types()
+                ),
+                notes=self._create_from_subject_typelist(sub, Note.valid_types),
+                sources=self._create_sources(sub),
+                languages=self._create_languages(sub),
+                extra_data=self._create_extra_data(sub, _KNOWN_CONCEPTSCHEME_PREDICATES),
+            )
+            cslist.append(cs)
+        if len(cslist) == 0:
+            return ConceptScheme(
+                uri=DefaultConceptSchemeUrnGenerator().generate(id=metadata.get("id"))
+            )
+        elif len(cslist) == 1:
+            return cslist[0]
+        else:
+            if not "concept_scheme_uri" in kwargs:
+                raise RuntimeError(
+                    "This RDF file contains more than one ConceptScheme. \
+                    Please specify one. The following schemes were found: \
+                    %s"
+                    % (", ".join([str(cs.uri) for cs in cslist]))
+                )
+            else:
+                self.check_in_scheme = True
+                csuri = kwargs["concept_scheme_uri"]
+                filteredcslist = [cs for cs in cslist if cs.uri == csuri]
+                if len(filteredcslist) == 0:
+                    raise RuntimeError(
+                        "This RDF file contains more than one ConceptScheme. \
+                        You specified an unexisting one. The following schemes \
+                        were found: %s"
+                        % (", ".join([str(cs.uri) for cs in cslist]))
+                    )
+                else:
+                    return filteredcslist[0]
+
+    def _from_graph(self):
+        clist = []
+        for sub, pred, obj in self.graph.triples((None, RDF.type, SKOS.Concept)):
+            if (
+                self.check_in_scheme
+                and self._get_in_scheme(sub) != self.concept_scheme.uri
+            ):
+                continue
+            uri = self.to_text(sub)
+            matches = {}
+            for k in Concept.matchtypes:
+                matches[k] = self._create_from_subject_predicate(
+                    sub, URIRef(SKOS[k + "Match"])
+                )
+            con = Concept(
+                id=self._get_id_for_subject(sub, uri),
+                uri=uri,
+                concept_scheme=self.concept_scheme,
+                labels=self._create_from_subject_typelist(
+                    sub, self._scrub_label_types()
+                ),
+                notes=self._create_from_subject_typelist(sub, Note.valid_types),
+                sources=self._create_sources(sub),
+                broader=self._create_from_subject_predicate(sub, SKOS.broader),
+                narrower=self._create_from_subject_predicate(sub, SKOS.narrower),
+                related=self._create_from_subject_predicate(sub, SKOS.related),
+                member_of=[],
+                subordinate_arrays=self._create_from_subject_predicate(
+                    sub, SKOS_THES.subordinateArray
+                ),
+                matches=matches,
+                extra_data=self._create_extra_data(sub, _KNOWN_CONCEPT_PREDICATES),
+            )
+            clist.append(con)
+
+        for sub, pred, obj in self.graph.triples((None, RDF.type, SKOS.Collection)):
+            if (
+                self.check_in_scheme
+                and self._get_in_scheme(sub) != self.concept_scheme.uri
+            ):
+                continue
+            uri = self.to_text(sub)
+            col = Collection(
+                id=self._get_id_for_subject(sub, uri),
+                uri=uri,
+                concept_scheme=self.concept_scheme,
+                labels=self._create_from_subject_typelist(
+                    sub, self._scrub_label_types()
+                ),
+                notes=self._create_from_subject_typelist(sub, (Note.valid_types)),
+                sources=self._create_sources(sub),
+                members=self._create_from_subject_predicate(sub, SKOS.member),
+                member_of=[],
+                superordinates=self._create_from_subject_predicate(
+                    sub, SKOS_THES.superOrdinate
+                ),
+                extra_data=self._create_extra_data(sub, _KNOWN_COLLECTION_PREDICATES),
+            )
+            clist.append(col)
+        self._fill_member_of(clist)
+        self._set_infer_concept_relations(clist)
+        return clist
+
+    def _get_in_scheme(self, subject):
+        """
+        Determine if a subject is part of a scheme.
+
+        :param subject: Subject to get the sources for.
+        :returns: A URI for the scheme a subject is part of or None if
+            it's not part of a scheme.
+        """
+        scheme = None
+        scheme = self.graph.value(subject, SKOS.inScheme)
+        if not scheme:
+            scheme = self.graph.value(subject, SKOS.topConceptOf)
+        return self.to_text(scheme) if scheme else None
+
+    def _fill_member_of(self, clist):
+        collections = list({c for c in clist if isinstance(c, Collection)})
+        for col in collections:
+            for c in clist:
+                if c.id in col.members:
+                    c.member_of.append(col.id)
+        return
+
+    def _set_infer_concept_relations(self, clist):
+        collections = list({c for c in clist if isinstance(c, Collection)})
+        for col in collections:
+            if not col.superordinates:
+                col.infer_concept_relations = False
+                continue
+
+            def _collect_broader(collection, clist):
+                """
+                Collect all broader concepts of members of a collection or
+                their (recursive) members.
+                """
+                members = list({c for c in clist if c.id in collection.members})
+                broader = []
+                for m in members:
+                    if m.type == "concept":
+                        broader.extend(m.broader)
+                    elif m.type == "collection":
+                        broader.extend(_collect_broader(m, clist))
+                return broader
+
+            broader = _collect_broader(col, clist)
+            col.infer_concept_relations = (
+                len(set(broader).intersection(col.superordinates)) > 0
+            )
+
+    def _create_extra_data(self, subject, known_predicates: frozenset) -> rdflib.Graph | None:
+        """Return a Graph of triples for subject whose predicate is not in known_predicates."""
+        g = rdflib.Graph()
+        for s, p, o in self.graph.triples((subject, None, None)):
+            if p not in known_predicates:
+                g.add((s, p, o))
+        return g if len(g) > 0 else None
+
+    def _create_from_subject_typelist(self, subject, typelist):
+        list = []
+        for p in typelist:
+            term = SKOS.__getitem__(p)
+            list.extend(self._create_from_subject_predicate(subject, term))
+        return list
+
+    def _get_id_for_subject(self, subject, uri):
+        if (subject, DCTERMS.identifier, None) in self.graph:
+            return self.to_text(
+                self.graph.value(
+                    subject=subject, predicate=DCTERMS.identifier, any=False
+                )
+            )
+        elif (subject, DC.identifier, None) in self.graph:
+            return self.to_text(
+                self.graph.value(subject=subject, predicate=DC.identifier, any=False)
+            )
+        else:
+            return uri
+
+    def _create_from_subject_predicate(self, subject, predicate):
+        list = []
+        for s, p, o in self.graph.triples((subject, predicate, None)):
+            type = predicate.split("#")[-1]
+            if Label.is_valid_type(type):
+                o = self._create_label(o, type)
+            elif Note.is_valid_type(type):
+                o = self._create_note(o, type)
+            else:
+                o = self._get_id_for_subject(o, self.to_text(o))
+            list.append(o)
+        return list
+
+    def _create_label(self, literal, type):
+        if not Label.is_valid_type(type):
+            raise ValueError("Type of Label is not valid.")
+        return Label(
+            self.to_text(literal), type, self._get_language_from_literal(literal)
+        )
+
+    def _read_markupped_literal(self, literal):
+        if literal.datatype == RDF.HTML:
+            df = literal.value.cloneNode(True)
+            if (
+                df.firstChild
+                and df.firstChild.attributes
+                and "xml:lang" in df.firstChild.attributes.keys()
+            ):
+                lang = self._scrub_language(
+                    df.firstChild.attributes.get("xml:lang").value
+                )
+                del df.firstChild.attributes["xml:lang"]
+            else:
+                lang = "und"
+            return ("".join(child.toxml() for child in df.childNodes), lang, "HTML")
+        else:
+            return (literal, self._get_language_from_literal(literal), None)
+
+    def _create_note(self, literal, type):
+        if not Note.is_valid_type(type):
+            raise ValueError("Type of Note is not valid.")
+        l = self._read_markupped_literal(literal)
+        return Note(self.to_text(l[0]), type, l[1], l[2])
+
+    def _create_sources(self, subject):
+        """
+        Create the sources for this subject.
+
+        :param subject: Subject to get the sources for.
+        :returns: A :class:`list` of :class:`skosprovider.skos.Source` objects.
+        """
+        ret = []
+        for s, p, o in self.graph.triples((subject, DCTERMS.source, None)):
+            for si, pi, oi in self.graph.triples(
+                (o, DCTERMS.bibliographicCitation, None)
+            ):
+                ret.append(
+                    Source(
+                        self.to_text(oi), "HTML" if oi.datatype == RDF.HTML else None
+                    )
+                )
+        return ret
+
+    def _create_languages(self, subject):
+        """
+        Create the languages for this subject.
+
+        :param subject: Subject to get the sources for.
+        :returns: A :class:`list` of IANA language tags.
+        """
+        ret = set()
+        for s, p, o in self.graph.triples((subject, DCTERMS.language, None)):
+            ret.add(self.to_text(self._scrub_language(o)))
+        for s, p, o in self.graph.triples((subject, DC.language, None)):
+            ret.add(self.to_text(self._scrub_language(o)))
+        return ret
+
+    def _scrub_language(self, language):
+        if tags.check(language):
+            return language
+        else:
+            log.warning(
+                'Encountered an invalid language %s. Falling back to "und".' % language
+            )
+            return "und"
+
+    def _scrub_label_types(self):
+        valid_label_types = Label.valid_types[:]
+        if "sortLabel" in valid_label_types:
+            valid_label_types.remove("sortLabel")
+        return valid_label_types
+
+    def _get_language_from_literal(self, data):
+        if not hasattr(data, "language") or data.language is None:
+            return None
+        return self.to_text(self._scrub_language(data.language))
+
+    def to_text(self, data):
+        """
+        data of binary type or literal type that needs to be converted to text.
+        :param data
+        :return: text representation of the data
+        """
+        return text_(data.encode("utf-8"), "utf-8")

--- a/skosprovider/rdf/utils.py
+++ b/skosprovider/rdf/utils.py
@@ -1,0 +1,350 @@
+"""
+This module contains utility functions for dealing with skos providers.
+"""
+
+import logging
+from typing import Callable
+from typing import TypeAlias
+
+from rdflib import Graph
+from rdflib import Literal
+from rdflib import Namespace
+from rdflib.namespace import DCTERMS
+from rdflib.namespace import RDF
+from rdflib.namespace import SKOS
+from rdflib.namespace import VOID
+from rdflib.term import BNode
+from rdflib.term import URIRef
+
+from skosprovider.skos import Collection
+from skosprovider.skos import Concept
+from skosprovider.skos import ConceptScheme
+from skosprovider.skos import Label
+from skosprovider.skos import Note
+from skosprovider.skos import Source
+from skosprovider.utils import add_lang_to_html
+from skosprovider.utils import extract_language
+
+SkosObject: TypeAlias = Concept | Collection | ConceptScheme | Label | Note | Source
+
+RdfSerializer: TypeAlias = Callable[[Graph, URIRef, SkosObject], None] | None
+"""A callable that receives a graph, a subject URIRef and a SKOS object, and
+adds extra triples to the graph.  Called only when the object's
+:attr:`extra_data` is not :obj:`None`.
+
+Example::
+
+    from rdflib.namespace import SKOS
+    from rdflib import Literal
+
+    def my_serializer(graph, subject, obj):
+        if isinstance(obj.extra_data, dict):
+            for notation in obj.extra_data.get("notation", []):
+                graph.add((subject, SKOS.notation, Literal(notation)))
+
+    result = rdf_dumper(provider, extra_data_serializer=my_serializer)
+"""
+
+SKOS_THES = Namespace("http://purl.org/iso25964/skos-thes#")
+log = logging.getLogger(__name__)
+
+
+def rdf_dumper(provider, extra_data_serializer: RdfSerializer = None):
+    """
+    Dump a provider to a format that can be passed to a
+    :class:`skosprovider.providers.RDFProvider`.
+
+    :param skosprovider.providers.VocabularyProvider provider: The provider
+        that wil be turned into an :class:`rdflib.graph.Graph`.
+
+    :param extra_data_serializer: Optional :data:`RdfSerializer` callable that
+        receives ``(graph, subject, skos_object)`` and adds extra triples for
+        objects that carry :attr:`~skosprovider.skos.Concept.extra_data`.
+
+    :rtype: :class:`rdflib.graph.Graph`
+    """
+    return _rdf_dumper(provider, None, extra_data_serializer)
+
+
+def rdf_c_dumper(provider, c, extra_data_serializer: RdfSerializer = None):
+    """
+    Dump one concept or collection from a provider to a format that can be passed to a
+    :class:`skosprovider.providers.RDFProvider`.
+
+    :param skosprovider.providers.VocabularyProvider provider: The provider
+        that wil be turned into an :class:`rdflib.graph.Graph`.
+
+    :param String c: identifier
+
+    :param extra_data_serializer: Optional :data:`RdfSerializer` callable.
+        See :func:`rdf_dumper`.
+
+    :rtype: :class:`rdflib.graph.Graph`
+    """
+    return _rdf_dumper(provider, [c], extra_data_serializer)
+
+
+def _rdf_dumper(provider, id_list=None, extra_data_serializer: RdfSerializer = None):
+    """
+    Dump a provider to a format that can be passed to a
+    :class:`skosprovider.providers.RDFProvider`.
+
+    :param skosprovider.providers.VocabularyProvider provider: The provider
+        that wil be turned into an :class:`rdflib.graph.Graph`.
+
+    :param List id_list: List of id's of the data to dump.
+
+    :param extra_data_serializer: Optional :data:`RdfSerializer` callable.
+        See :func:`rdf_dumper`.
+
+    :rtype: :class:`rdflib.graph.Graph`
+    """
+    graph = Graph()
+    graph.namespace_manager.bind("skos", SKOS)
+    graph.namespace_manager.bind("dcterms", DCTERMS)
+    graph.namespace_manager.bind("skos-thes", SKOS_THES)
+    graph.namespace_manager.bind("void", VOID)
+    conceptscheme = URIRef(provider.concept_scheme.uri)
+    _add_in_dataset(graph, conceptscheme, provider)
+    graph.add((conceptscheme, RDF.type, SKOS.ConceptScheme))
+    graph.add((conceptscheme, DCTERMS.identifier, Literal(provider.metadata["id"])))
+    _add_labels(graph, provider.concept_scheme, conceptscheme)
+    _add_notes(graph, provider.concept_scheme, conceptscheme)
+    _add_sources(graph, provider.concept_scheme, conceptscheme)
+    _add_languages(graph, provider.concept_scheme, conceptscheme)
+    if extra_data_serializer is not None and provider.concept_scheme.extra_data is not None:
+        extra_data_serializer(graph, conceptscheme, provider.concept_scheme)
+    # Add triples using store's add method.
+    if not id_list:
+        id_list = [x["id"] for x in provider.get_all()]
+        for c in provider.get_top_concepts():
+            graph.add((conceptscheme, SKOS.hasTopConcept, URIRef(c["uri"])))
+    for id in id_list:
+        _add_c(graph, provider, id, extra_data_serializer)
+
+    return graph
+
+
+def rdf_conceptscheme_dumper(provider, extra_data_serializer: RdfSerializer = None):
+    """
+    Dump all information of the conceptscheme of a provider to a format that can be passed to a
+    :class:`skosprovider.providers.RDFProvider`.
+
+    :param skosprovider.providers.VocabularyProvider provider: The provider
+        that wil be turned into an :class:`rdflib.graph.Graph`.
+
+    :param extra_data_serializer: Optional :data:`RdfSerializer` callable.
+        See :func:`rdf_dumper`.
+
+    :rtype: :class:`rdflib.graph.Graph`
+    """
+    graph = Graph()
+    graph.namespace_manager.bind("skos", SKOS)
+    graph.namespace_manager.bind("dcterms", DCTERMS)
+    graph.namespace_manager.bind("skos-thes", SKOS_THES)
+    graph.namespace_manager.bind("void", VOID)
+    conceptscheme = URIRef(provider.concept_scheme.uri)
+    _add_in_dataset(graph, conceptscheme, provider)
+    graph.add((conceptscheme, RDF.type, SKOS.ConceptScheme))
+    graph.add((conceptscheme, DCTERMS.identifier, Literal(provider.metadata["id"])))
+    _add_labels(graph, provider.concept_scheme, conceptscheme)
+    _add_notes(graph, provider.concept_scheme, conceptscheme)
+    _add_sources(graph, provider.concept_scheme, conceptscheme)
+    _add_languages(graph, provider.concept_scheme, conceptscheme)
+    if extra_data_serializer is not None and provider.concept_scheme.extra_data is not None:
+        extra_data_serializer(graph, conceptscheme, provider.concept_scheme)
+    for c in provider.get_top_concepts():
+        graph.add((conceptscheme, SKOS.hasTopConcept, URIRef(c["uri"])))
+
+    return graph
+
+
+def _add_in_dataset(graph, subject, provider):
+    """
+    Checks if the provider says something about a dataset and if so adds
+    void.inDataset statements.
+
+    :param rdflib.graph.Graph graph: The graph to add statements to.
+    :param rdflib.term.URIRef subject: The subject to add an inDataset statement to.
+    :param skosprovider.providers.VocabularyProvider provider:
+    """
+
+    duri = provider.get_metadata().get("dataset", {}).get("uri", None)
+    if duri:
+        graph.add((subject, VOID.inDataset, URIRef(duri)))
+
+
+def _add_c(graph, provider, id, extra_data_serializer: RdfSerializer = None):
+    """
+    Adds a concept or collection to the graph.
+
+    :param rdflib.graph.Graph graph: The graph to add statements to.
+    :param skosprovider.providers.VocabularyProvider provider: Provider
+    :param c: The id of a concept or collection.
+    :param extra_data_serializer: Optional :data:`RdfSerializer` callable.
+    """
+
+    c = provider.get_by_id(id)
+    subject = URIRef(c.uri)
+    _add_in_dataset(graph, subject, provider)
+    if c.id != c.uri:
+        graph.add((subject, DCTERMS.identifier, Literal(c.id)))
+    conceptscheme = URIRef(provider.concept_scheme.uri)
+    graph.add((subject, SKOS.inScheme, conceptscheme))
+    _add_labels(graph, c, subject)
+    _add_notes(graph, c, subject)
+    _add_sources(graph, c, subject)
+    if extra_data_serializer is not None and c.extra_data is not None:
+        extra_data_serializer(graph, subject, c)
+    if isinstance(c, Concept):
+        graph.add((subject, RDF.type, SKOS.Concept))
+        for b in c.broader:
+            broader = provider.get_by_id(b)
+            if broader:
+                graph.add((subject, SKOS.broader, URIRef(broader.uri)))
+        for n in c.narrower:
+            narrower = provider.get_by_id(n)
+            if narrower:
+                graph.add((subject, SKOS.narrower, URIRef(narrower.uri)))
+        for r in c.related:
+            related = provider.get_by_id(r)
+            if related:
+                graph.add((subject, SKOS.related, URIRef(related.uri)))
+        for s in c.subordinate_arrays:
+            subordinate_array = provider.get_by_id(s)
+            if subordinate_array:
+                graph.add(
+                    (subject, SKOS_THES.subordinateArray, URIRef(subordinate_array.uri))
+                )
+                if subordinate_array.infer_concept_relations:
+
+                    def _add_coll_members_to_superordinate(so, members):
+                        """
+                        Recursively create broader/narrower relations between
+                        collection members and the superordinate concept
+                        """
+                        for m in members:
+                            member = provider.get_by_id(m)
+                            if member.type == "concept":
+                                graph.add((so, SKOS.narrower, URIRef(member.uri)))
+                                graph.add((URIRef(member.uri), SKOS.broader, so))
+                            elif member.type == "collection":
+                                _add_coll_members_to_superordinate(so, member.members)
+
+                    _add_coll_members_to_superordinate(
+                        subject, subordinate_array.members
+                    )
+        for coll in c.member_of:
+            collection = provider.get_by_id(coll)
+            if collection:
+                graph.add((URIRef(collection.uri), SKOS.member, subject))
+                graph.add((URIRef(collection.uri), RDF.type, SKOS.Collection))
+                graph.add((URIRef(collection.uri), SKOS.inScheme, conceptscheme))
+                graph.add(
+                    (URIRef(collection.uri), DCTERMS.identifier, Literal(collection.id))
+                )
+
+                def _add_coll_superordinates_as_broader(member, collection):
+                    """
+                    Recursively create broader relations between
+                    a collection member and the superordinate concepts
+                    """
+                    if collection.infer_concept_relations:
+                        for so in collection.superordinates:
+                            superordinate = provider.get_by_id(so)
+                            graph.add(
+                                (
+                                    URIRef(member.uri),
+                                    SKOS.broader,
+                                    URIRef(superordinate.uri),
+                                )
+                            )
+                        for pc in collection.member_of:
+                            parent_collection = provider.get_by_id(pc)
+                            _add_coll_superordinates_as_broader(
+                                member, parent_collection
+                            )
+
+                _add_coll_superordinates_as_broader(c, collection)
+        for k in c.matches.keys():
+            for uri in c.matches[k]:
+                graph.add((subject, URIRef(SKOS[k + "Match"]), URIRef(uri)))
+    elif isinstance(c, Collection):
+        graph.add((subject, RDF.type, SKOS.Collection))
+        for m in c.members:
+            member = provider.get_by_id(m)
+            if member:
+                graph.add((subject, SKOS.member, URIRef(member.uri)))
+        for s in c.superordinates:
+            superordinate = provider.get_by_id(s)
+            if superordinate:
+                graph.add((subject, SKOS_THES.superOrdinate, URIRef(superordinate.uri)))
+
+
+def _add_labels(graph, c, subject):
+    for l in c.labels:
+        labeltype = (
+            l.type
+            if l.type in ["prefLabel", "altLabel", "hiddenLabel"]
+            else "hiddenLabel"
+        )
+        predicate = URIRef(SKOS[labeltype])
+        lang = extract_language(l.language)
+        graph.add((subject, predicate, Literal(l.label, lang=lang)))
+
+
+def _add_notes(graph, c, subject):
+    for n in c.notes:
+        predicate = URIRef(SKOS[n.type])
+        lang = extract_language(n.language)
+        if n.markup is None:
+            graph.add((subject, predicate, Literal(n.note, lang=lang)))
+        else:
+            html = add_lang_to_html(n.note, lang)
+            graph.add((subject, predicate, Literal(html, datatype=RDF.HTML)))
+
+
+def _add_sources(graph, c, subject):
+    """
+    Add sources to the RDF graph.
+
+    :param rdflib.graph.Graph graph: An RDF Graph.
+    :param c: A :class:`skosprovider.skos.ConceptScheme`,
+        :class:`skosprovider.skos.Concept` or :class:`skosprovider.skos.Collection`
+    :param subject: The RDF subject to add the sources to.
+    """
+    for s in c.sources:
+        source = BNode()
+        graph.add((source, RDF.type, DCTERMS.BibliographicResource))
+        if s.markup is None:
+            graph.add((source, DCTERMS.bibliographicCitation, Literal(s.citation)))
+        else:
+            graph.add(
+                (
+                    source,
+                    DCTERMS.bibliographicCitation,
+                    Literal(s.citation, datatype=RDF.HTML),
+                )
+            )
+        graph.add((subject, DCTERMS.source, source))
+
+
+def _add_languages(graph, c, subject):
+    """
+    Add languages to the RDF graph.
+
+    :param rdflib.graph.Graph graph: An RDF Graph.
+    :param c: A :class:`skosprovider.skos.ConceptScheme`.
+    :param subject: The RDF subject to add the sources to.
+    """
+    for l in c.languages:
+        lang = extract_language(l)
+        graph.add((subject, DCTERMS.language, Literal(l)))
+
+
+def text_(s, encoding="latin-1", errors="strict"):
+    """If ``s`` is an instance of ``bytes``, return
+    ``s.decode(encoding, errors)``, otherwise return ``s``"""
+    if isinstance(s, bytes):
+        return s.decode(encoding, errors)
+    return s

--- a/skosprovider/registry.py
+++ b/skosprovider/registry.py
@@ -8,7 +8,6 @@ import logging
 
 from .uri import is_uri
 
-
 log = logging.getLogger(__name__)
 
 

--- a/tests/data/materiaal.txt
+++ b/tests/data/materiaal.txt
@@ -1,0 +1,1716 @@
+{
+    "materiaal": [
+        {
+            "subordinate_arrays": [],
+            "concept_scheme": {
+                "notes": [],
+                "labels": [],
+                "uri": "urn:x-skosprovider:materials"
+            },
+            "member_of": [
+                0
+            ],
+            "notes": [
+                {
+                    "note": "Aardewerk of keramiek is gebakken klei. Aardewerk wordt gebruikt voor het vervaardigen van vaatwerk, bouwmaterialen, beeldjes, enz…",
+                    "type": "definition",
+                    "language": "nl-BE"
+                },
+                {
+                    "note": "Nederlandse Art &amp; Architecture Thesaurus, <a href=\"http://browser.aat-ned.nl/\">http://browser.aat-ned.nl/</a>",
+                    "type": "note",
+                    "language": "nl-BE"
+                }
+            ],
+            "labels": [
+                {
+                    "type": "prefLabel",
+                    "language": "nl-BE",
+                    "label": "aardewerk"
+                },
+                {
+                    "type": "altLabel",
+                    "language": "nl-BE",
+                    "label": "ceramiek"
+                },
+                {
+                    "type": "altLabel",
+                    "language": "nl-BE",
+                    "label": "keramiek"
+                }
+            ],
+            "narrower": [
+                2,
+                5,
+                6
+            ],
+            "uri": "https://id.erfgoed.net/thesauri/materialen/1",
+            "related": [],
+            "broader": [],
+            "type": "concept",
+            "id": 1
+        },
+        {
+            "subordinate_arrays": [],
+            "concept_scheme": {
+                "notes": [],
+                "labels": [],
+                "uri": "urn:x-skosprovider:materials"
+            },
+            "member_of": [],
+            "notes": [
+                {
+                    "note": "Aluminium is een metaal uit de derde groep van het periodiek systeem (chemisch element Al). Het is dof zilverachtig van kleur en zeer licht.",
+                    "type": "definition",
+                    "language": "nl-BE"
+                },
+                {
+                    "note": "Van Dale groot woordenboek van de Nederlandse taal. 14de editie, Utrecht/Antwerpen, 2005",
+                    "type": "note",
+                    "language": "nl-BE"
+                }
+            ],
+            "labels": [
+                {
+                    "type": "prefLabel",
+                    "language": "nl-BE",
+                    "label": "aluminium"
+                }
+            ],
+            "narrower": [],
+            "uri": "https://id.erfgoed.net/thesauri/materialen/48",
+            "related": [],
+            "broader": [
+                8
+            ],
+            "type": "concept",
+            "id": 48
+        },
+        {
+            "subordinate_arrays": [],
+            "concept_scheme": {
+                "notes": [],
+                "labels": [],
+                "uri": "urn:x-skosprovider:materials"
+            },
+            "member_of": [],
+            "notes": [
+                {
+                    "note": "Amber is een fossiele hars afkomstig uit naaldbomen en wordt gebruikt voor het maken van kralen, hangers, knopen en dergelijke meer.",
+                    "type": "definition",
+                    "language": "nl-BE"
+                },
+                {
+                    "note": "VIOE",
+                    "type": "note",
+                    "language": "nl-BE"
+                }
+            ],
+            "labels": [
+                {
+                    "type": "prefLabel",
+                    "language": "nl-BE",
+                    "label": "amber"
+                },
+                {
+                    "type": "altLabel",
+                    "language": "nl-BE",
+                    "label": "barnsteen"
+                }
+            ],
+            "narrower": [],
+            "uri": "https://id.erfgoed.net/thesauri/materialen/33",
+            "related": [],
+            "broader": [
+                32
+            ],
+            "type": "concept",
+            "id": 33
+        },
+        {
+            "subordinate_arrays": [68],
+            "concept_scheme": {
+                "notes": [],
+                "labels": [],
+                "uri": "urn:x-skosprovider:materials"
+            },
+            "member_of": [
+                0
+            ],
+            "notes": [
+                {
+                    "note": "Beton is een kunstmatig materiaal dat lijkt op steen en als bouwmateriaal gebruikt wordt. Het bestaat uit cement of kalk waaraan zand, grind of steenslag wordt toegevoegd.",
+                    "type": "definition",
+                    "language": "nl-BE"
+                },
+                {
+                    "note": "VIOE",
+                    "type": "note",
+                    "language": "nl-BE"
+                }
+            ],
+            "labels": [
+                {
+                    "type": "prefLabel",
+                    "language": "nl-BE",
+                    "label": "beton"
+                }
+            ],
+            "narrower": [],
+            "uri": "https://id.erfgoed.net/thesauri/materialen/38",
+            "related": [],
+            "broader": [],
+            "type": "concept",
+            "id": 38
+        },
+        {
+            "subordinate_arrays": [],
+            "concept_scheme": {
+                "notes": [],
+                "labels": [],
+                "uri": "urn:x-skosprovider:materials"
+            },
+            "member_of": [],
+            "notes": [
+                {
+                    "note": "Bladgoud is een term die verwijst naar platen goud die tot een zeer geringe dikte (meestal circa 0,1 micrometer) zijn gehamerd of gewalst.",
+                    "type": "definition",
+                    "language": "nl-BE"
+                },
+                {
+                    "note": "Nederlandse Art &amp; Architecture Thesaurus, <a href=\"http://browser.aat-ned.nl/\">http://browser.aat-ned.nl/</a>",
+                    "type": "note",
+                    "language": "nl-BE"
+                }
+            ],
+            "labels": [
+                {
+                    "type": "prefLabel",
+                    "language": "nl-BE",
+                    "label": "bladgoud"
+                }
+            ],
+            "narrower": [],
+            "uri": "https://id.erfgoed.net/thesauri/materialen/10",
+            "related": [],
+            "broader": [
+                9
+            ],
+            "type": "concept",
+            "id": 10
+        },
+        {
+            "subordinate_arrays": [],
+            "concept_scheme": {
+                "notes": [],
+                "labels": [],
+                "uri": "urn:x-skosprovider:materials"
+            },
+            "member_of": [],
+            "notes": [
+                {
+                    "note": "Bont is een gelooide dierlijke huid, dicht bezet met haren. Het wordt voornamelijk gebruikt voor het maken van kleding.",
+                    "type": "definition",
+                    "language": "nl-BE"
+                },
+                {
+                    "note": "Nederlandse Art &amp; Architecture Thesaurus, <a href=\"http://browser.aat-ned.nl/\">http://browser.aat-ned.nl/</a>",
+                    "type": "note",
+                    "language": "nl-BE"
+                }
+            ],
+            "labels": [
+                {
+                    "type": "prefLabel",
+                    "language": "nl-BE",
+                    "label": "bont"
+                }
+            ],
+            "narrower": [],
+            "uri": "https://id.erfgoed.net/thesauri/materialen/23",
+            "related": [],
+            "broader": [
+                21
+            ],
+            "type": "concept",
+            "id": 23
+        },
+        {
+            "subordinate_arrays": [],
+            "concept_scheme": {
+                "notes": [],
+                "labels": [],
+                "uri": "urn:x-skosprovider:materials"
+            },
+            "member_of": [],
+            "notes": [
+                {
+                    "note": "Botmateriaal of been is een combinatie van organisch en anorganisch materiaal die hoofdzakelijk bestaat uit collageen en calciumfosfaat.",
+                    "type": "definition",
+                    "language": "nl-BE"
+                },
+                {
+                    "note": "Nederlandse Art &amp; Architecture Thesaurus, <a href=\"http://browser.aat-ned.nl/\">http://browser.aat-ned.nl/</a>",
+                    "type": "note",
+                    "language": "nl-BE"
+                }
+            ],
+            "labels": [
+                {
+                    "type": "prefLabel",
+                    "language": "nl-BE",
+                    "label": "botmateriaal"
+                }
+            ],
+            "narrower": [
+                25,
+                26
+            ],
+            "uri": "https://id.erfgoed.net/thesauri/materialen/24",
+            "related": [],
+            "broader": [
+                21
+            ],
+            "type": "concept",
+            "id": 24
+        },
+        {
+            "subordinate_arrays": [],
+            "concept_scheme": {
+                "notes": [],
+                "labels": [],
+                "uri": "urn:x-skosprovider:materials"
+            },
+            "member_of": [13],
+            "notes": [
+                {
+                    "note": "Brons is een legering van koper en tin.",
+                    "type": "definition",
+                    "language": "nl-BE"
+                }
+            ],
+            "labels": [
+                {
+                    "type": "prefLabel",
+                    "language": "nl-BE",
+                    "label": "brons"
+                }
+            ],
+            "narrower": [],
+            "uri": "https://id.erfgoed.net/thesauri/materialen/14",
+            "related": [],
+            "broader": [],
+            "type": "concept",
+            "id": 14
+        },
+        {
+            "subordinate_arrays": [],
+            "concept_scheme": {
+                "notes": [],
+                "labels": [],
+                "uri": "urn:x-skosprovider:materials"
+            },
+            "member_of": [
+                0
+            ],
+            "notes": [
+                {
+                    "note": "Cement is de benaming voor verschillende stoffen die een snel verhardend bindmiddel voor bouwwerken (mortel) opleveren.",
+                    "type": "definition",
+                    "language": "nl-BE"
+                },
+                {
+                    "note": "Van Dale groot woordenboek van de Nederlandse taal. 14de editie, Utrecht/Antwerpen, 2005",
+                    "type": "note",
+                    "language": "nl-BE"
+                }
+            ],
+            "labels": [
+                {
+                    "type": "prefLabel",
+                    "language": "nl-BE",
+                    "label": "cement"
+                }
+            ],
+            "narrower": [],
+            "uri": "https://id.erfgoed.net/thesauri/materialen/49",
+            "related": [],
+            "broader": [],
+            "type": "concept",
+            "id": 49
+        },
+        {
+            "subordinate_arrays": [],
+            "concept_scheme": {
+                "notes": [],
+                "labels": [],
+                "uri": "urn:x-skosprovider:materials"
+            },
+            "member_of": [],
+            "notes": [
+                {
+                    "note": "Botmateriaal of been is een combinatie van organisch en anorganisch materiaal die hoofdzakelijk bestaat uit collageen en calciumfosfaat; het vormt het geraamte van de meeste gewervelde dieren.",
+                    "type": "definition",
+                    "language": "nl-BE"
+                },
+                {
+                    "note": "Nederlandse Art &amp; Architecture Thesaurus, <a href=\"http://browser.aat-ned.nl/\">http://browser.aat-ned.nl/</a>",
+                    "type": "note",
+                    "language": "nl-BE"
+                }
+            ],
+            "labels": [
+                {
+                    "type": "prefLabel",
+                    "language": "nl-BE",
+                    "label": "dierlijk botmateriaal"
+                }
+            ],
+            "narrower": [],
+            "uri": "https://id.erfgoed.net/thesauri/materialen/25",
+            "related": [],
+            "broader": [
+                24
+            ],
+            "type": "concept",
+            "id": 25
+        },
+        {
+            "subordinate_arrays": [],
+            "concept_scheme": {
+                "notes": [],
+                "labels": [],
+                "uri": "urn:x-skosprovider:materials"
+            },
+            "member_of": [],
+            "notes": [
+                {
+                    "note": "Gewapend beton is een combinatie van beton en staal.",
+                    "type": "definition",
+                    "language": "nl-BE"
+                }
+            ],
+            "labels": [
+                {
+                    "type": "prefLabel",
+                    "language": "nl-BE",
+                    "label": "gewapend beton"
+                }
+            ],
+            "narrower": [],
+            "uri": "https://id.erfgoed.net/thesauri/materialen/39",
+            "related": [],
+            "broader": [
+                38
+            ],
+            "type": "concept",
+            "id": 39
+        },
+        {
+            "subordinate_arrays": [],
+            "concept_scheme": {
+                "notes": [],
+                "labels": [],
+                "uri": "urn:x-skosprovider:materials"
+            },
+            "member_of": [],
+            "notes": [
+                {
+                    "note": "Gewei wordt gevormd door enkele uitstulpingen van been op de voorhoofdsbeenderen van gehoefde dieren die behoren tot de hertenfamilie. Het wordt jaarlijks afgeworpen. Gewei wordt door de mens gebruikt als grondstof voor het maken van artefacten.",
+                    "type": "definition",
+                    "language": "nl-BE"
+                },
+                {
+                    "note": "Nederlandse Art &amp; Architecture Thesaurus, <a href=\"http://browser.aat-ned.nl/\">http://browser.aat-ned.nl/</a>",
+                    "type": "note",
+                    "language": "nl-BE"
+                }
+            ],
+            "labels": [
+                {
+                    "type": "prefLabel",
+                    "language": "nl-BE",
+                    "label": "gewei"
+                }
+            ],
+            "narrower": [],
+            "uri": "https://id.erfgoed.net/thesauri/materialen/27",
+            "related": [],
+            "broader": [
+                21
+            ],
+            "type": "concept",
+            "id": 27
+        },
+        {
+            "subordinate_arrays": [],
+            "concept_scheme": {
+                "notes": [],
+                "labels": [],
+                "uri": "urn:x-skosprovider:materials"
+            },
+            "member_of": [
+                0
+            ],
+            "notes": [
+                {
+                    "note": "Glas is een amorfe, anorganische substantie die wordt gemaakt door silica (siliciumdioxide) te fuseren met een basisoxide, meestal transparant maar vaak ook doorzichtig of ondoorschijnend.",
+                    "type": "definition",
+                    "language": "nl-BE"
+                },
+                {
+                    "note": "Nederlandse Art &amp; Architecture Thesaurus, <a href=\"http://browser.aat-ned.nl/\">http://browser.aat-ned.nl/</a>",
+                    "type": "note",
+                    "language": "nl-BE"
+                }
+            ],
+            "labels": [
+                {
+                    "type": "prefLabel",
+                    "language": "nl-BE",
+                    "label": "glas"
+                }
+            ],
+            "narrower": [],
+            "uri": "https://id.erfgoed.net/thesauri/materialen/7",
+            "related": [],
+            "broader": [],
+            "type": "concept",
+            "id": 7
+        },
+        {
+            "subordinate_arrays": [],
+            "concept_scheme": {
+                "notes": [],
+                "labels": [],
+                "uri": "urn:x-skosprovider:materials"
+            },
+            "member_of": [],
+            "notes": [
+                {
+                    "note": "Te gebruiken voor het zuivere metaalelement met het symbool Au. Het is een zacht, zwaar, chemisch inactief en geel metaal en wordt al sinds de oudheid als edel beschouwd. Het dient in vele culturen als de basis voor materiële handelswaarden. Ook te gebruiken voor het metaal wanneer het wordt bewerkt en vervormd om, meestal in combinatie met andere stoffen, verschillende voorwerpen en materialen te maken.",
+                    "type": "definition",
+                    "language": "nl-BE"
+                },
+                {
+                    "note": "Nederlandse Art &amp; Architecture Thesaurus, <a href=\"http://browser.aat-ned.nl/\">http://browser.aat-ned.nl/</a>",
+                    "type": "note",
+                    "language": "nl-BE"
+                }
+            ],
+            "labels": [
+                {
+                    "type": "prefLabel",
+                    "language": "nl-BE",
+                    "label": "goud"
+                }
+            ],
+            "narrower": [
+                10
+            ],
+            "uri": "https://id.erfgoed.net/thesauri/materialen/9",
+            "related": [],
+            "broader": [
+                8
+            ],
+            "type": "concept",
+            "id": 9
+        },
+        {
+            "subordinate_arrays": [],
+            "concept_scheme": {
+                "notes": [],
+                "labels": [],
+                "uri": "urn:x-skosprovider:materials"
+            },
+            "member_of": [],
+            "notes": [
+                {
+                    "note": "Hoorn is een uitgroei van aangepaste huid of zeer compact haar, vaak in paren die uitsteken vanaf de voorhoofdsbotten aan beide zijden van de schedel en bestaat uit een permanente opperhuid van keratine. De benen kern van een hoorn wordt hoornpit genoemd.",
+                    "type": "definition",
+                    "language": "nl-BE"
+                },
+                {
+                    "note": "Nederlandse Art &amp; Architecture Thesaurus, <a href=\"http://browser.aat-ned.nl/\">http://browser.aat-ned.nl/</a>",
+                    "type": "note",
+                    "language": "nl-BE"
+                },
+                {
+                    "note": "Te onderscheiden van 'gewei', dat bestaat uit aangepast been.",
+                    "type": "scopeNote",
+                    "language": "nl-BE"
+                }
+            ],
+            "labels": [
+                {
+                    "type": "prefLabel",
+                    "language": "nl-BE",
+                    "label": "hoorn/hoornpitten"
+                }
+            ],
+            "narrower": [],
+            "uri": "https://id.erfgoed.net/thesauri/materialen/28",
+            "related": [],
+            "broader": [
+                21
+            ],
+            "type": "concept",
+            "id": 28
+        },
+        {
+            "subordinate_arrays": [],
+            "concept_scheme": {
+                "notes": [],
+                "labels": [],
+                "uri": "urn:x-skosprovider:materials"
+            },
+            "member_of": [],
+            "notes": [
+                {
+                    "note": "Hout is het voornaamste bestanddeel van bomen en struiken. Hout is een belangrijke grondstof en wordt voor allerlei toepassingen gebruikt, zoals voor bouwconstructies, als brandstof, voor het maken van papier, enz…",
+                    "type": "definition",
+                    "language": "nl-BE"
+                },
+                {
+                    "note": "Nederlandse Art &amp; Architecture Thesaurus, <a href=\"http://browser.aat-ned.nl/\">http://browser.aat-ned.nl/</a>",
+                    "type": "note",
+                    "language": "nl-BE"
+                }
+            ],
+            "labels": [
+                {
+                    "type": "prefLabel",
+                    "language": "nl-BE",
+                    "label": "hout"
+                }
+            ],
+            "narrower": [],
+            "uri": "https://id.erfgoed.net/thesauri/materialen/35",
+            "related": [],
+            "broader": [
+                32
+            ],
+            "type": "concept",
+            "id": 35
+        },
+        {
+            "subordinate_arrays": [],
+            "concept_scheme": {
+                "notes": [],
+                "labels": [],
+                "uri": "urn:x-skosprovider:materials"
+            },
+            "member_of": [],
+            "notes": [
+                {
+                    "note": "Houtskool is een onzuivere vorm van grafietkoolstof die ontstaat als reststof bij de gedeeltelijke verbranding van koolstofhoudend materiaal, of bij verhitting van dit materiaal waarbij zuurstof in beperkte hoeveelheid aanwezig is.",
+                    "type": "definition",
+                    "language": "nl-BE"
+                },
+                {
+                    "note": "Nederlandse Art &amp; Architecture Thesaurus, <a href=\"http://browser.aat-ned.nl/\">http://browser.aat-ned.nl/</a>",
+                    "type": "note",
+                    "language": "nl-BE"
+                }
+            ],
+            "labels": [
+                {
+                    "type": "prefLabel",
+                    "language": "nl-BE",
+                    "label": "houtskool"
+                }
+            ],
+            "narrower": [],
+            "uri": "https://id.erfgoed.net/thesauri/materialen/36",
+            "related": [],
+            "broader": [
+                32
+            ],
+            "type": "concept",
+            "id": 36
+        },
+        {
+            "subordinate_arrays": [],
+            "concept_scheme": {
+                "notes": [],
+                "labels": [],
+                "uri": "urn:x-skosprovider:materials"
+            },
+            "member_of": [],
+            "notes": [],
+            "labels": [
+                {
+                    "type": "prefLabel",
+                    "language": "nl-BE",
+                    "label": "huid"
+                }
+            ],
+            "narrower": [
+                30
+            ],
+            "uri": "https://id.erfgoed.net/thesauri/materialen/29",
+            "related": [],
+            "broader": [
+                21
+            ],
+            "type": "concept",
+            "id": 29
+        },
+        {
+            "subordinate_arrays": [],
+            "concept_scheme": {
+                "notes": [],
+                "labels": [],
+                "uri": "urn:x-skosprovider:materials"
+            },
+            "member_of": [],
+            "notes": [
+                {
+                    "note": "Te gebruiken voor het zuivere metaalelement met het symbool Fe. Het is een glimmend, zilverachtig zacht metaal dat roest wanneer het aan vochtige lucht wordt blootgesteld. Gebruik ook voor dit metaal als het wordt verwerkt en gevormd, meestal in combinatie met andere stoffen, om diverse objecten en materialen te maken.",
+                    "type": "definition",
+                    "language": "nl-BE"
+                },
+                {
+                    "note": "Nederlandse Art &amp; Architecture Thesaurus, <a href=\"http://browser.aat-ned.nl/\">http://browser.aat-ned.nl/</a>",
+                    "type": "note",
+                    "language": "nl-BE"
+                }
+            ],
+            "labels": [
+                {
+                    "type": "prefLabel",
+                    "language": "nl-BE",
+                    "label": "ijzer"
+                }
+            ],
+            "narrower": [],
+            "uri": "https://id.erfgoed.net/thesauri/materialen/11",
+            "related": [],
+            "broader": [
+                8
+            ],
+            "type": "concept",
+            "id": 11
+        },
+        {
+            "subordinate_arrays": [13],
+            "concept_scheme": {
+                "notes": [],
+                "labels": [],
+                "uri": "urn:x-skosprovider:materials"
+            },
+            "member_of": [],
+            "notes": [
+                {
+                    "note": "Te gebruiken voor het zuivere metaalelement met het symbool Cu. Het is roodachtig van kleur en is zeer smeedbaar en kneedbaar. Ook te gebruiken voor het metaal wanneer het wordt bewerkt en gevormd om, meestal in combinatie met andere stoffen, verschillende voorwerpen en materialen te maken.",
+                    "type": "definition",
+                    "language": "nl-BE"
+                },
+                {
+                    "note": "Nederlandse Art &amp; Architecture Thesaurus, <a href=\"http://browser.aat-ned.nl/\">http://browser.aat-ned.nl/</a>",
+                    "type": "note",
+                    "language": "nl-BE"
+                }
+            ],
+            "labels": [
+                {
+                    "type": "prefLabel",
+                    "language": "nl-BE",
+                    "label": "koper"
+                }
+            ],
+            "narrower": [],
+            "uri": "https://id.erfgoed.net/thesauri/materialen/12",
+            "related": [],
+            "broader": [
+                8
+            ],
+            "type": "concept",
+            "id": 12
+        },
+        {
+            "concept_scheme": {
+                "notes": [],
+                "labels": [],
+                "uri": "urn:x-skosprovider:materials"
+            },
+            "member_of": [],
+            "notes": [
+                {
+                    "note": "Een koperlegering is een vast mengsel van koper met andere metalen.",
+                    "type": "definition",
+                    "language": "nl-BE"
+                },
+                {
+                    "note": "VIOE",
+                    "type": "note",
+                    "language": "nl-BE"
+                }
+            ],
+            "labels": [
+                {
+                    "type": "prefLabel",
+                    "language": "nl-BE",
+                    "label": "koperlegeringen"
+                }
+            ],
+            "members": [
+                14,
+                15
+            ],
+            "uri": "https://id.erfgoed.net/thesauri/materialen/13",
+            "superordinates": [
+                12
+            ],
+            "infer_concept_relations": false,
+            "type": "collection",
+            "id": 13
+        },
+        {
+            "subordinate_arrays": [],
+            "concept_scheme": {
+                "notes": [],
+                "labels": [],
+                "uri": "urn:x-skosprovider:materials"
+            },
+            "member_of": [
+                0
+            ],
+            "notes": [
+                {
+                    "note": "Een kunststof is een langs chemische weg gemaakte stof die gebruikt wordt voor de vervaardiging van de meest verschillende zaken. In de scheepsbouw gaat het om een composiet van glasvezel (of andere meer moderne vezels) met polyester of epoxy, al dan niet in combinatie met een core-materiaal.",
+                    "type": "definition",
+                    "language": "nl-BE"
+                },
+                {
+                    "note": "1) Van Dale groot woordenboek van de Nederlandse taal. 14de editie, Utrecht/Antwerpen, 2005\n2) Onroerend Erfgoed",
+                    "type": "note",
+                    "language": "nl-BE"
+                }
+            ],
+            "labels": [
+                {
+                    "type": "prefLabel",
+                    "language": "nl-BE",
+                    "label": "kunststof"
+                }
+            ],
+            "narrower": [],
+            "uri": "https://id.erfgoed.net/thesauri/materialen/20",
+            "related": [],
+            "broader": [],
+            "type": "concept",
+            "id": 20
+        },
+        {
+            "subordinate_arrays": [],
+            "concept_scheme": {
+                "notes": [],
+                "labels": [],
+                "uri": "urn:x-skosprovider:materials"
+            },
+            "member_of": [43],
+            "notes": [
+                {
+                    "note": "Het kwartsiet van Tienen is een metamorf gesteente waarbij de oorspronkelijke sedimentaire kwartskorrels door secundaire aangroei met elkaar zijn vergroeid. Dit verklaart de geringe porositeit en sterke cohesie van dit gesteente.",
+                    "type": "definition",
+                    "language": "nl-BE"
+                },
+                {
+                    "note": "Gullentops F. &amp; Wouters L., Delfstoffen in Vlaanderen, Ministerie van de Vlaamse gemeenschap, Departement EWBL.",
+                    "type": "note",
+                    "language": "nl-BE"
+                }
+            ],
+            "labels": [
+                {
+                    "type": "prefLabel",
+                    "language": "nl-BE",
+                    "label": "kwartsiet van Tienen"
+                }
+            ],
+            "narrower": [],
+            "uri": "https://id.erfgoed.net/thesauri/materialen/44",
+            "related": [],
+            "broader": [],
+            "type": "concept",
+            "id": 44
+        },
+        {
+            "concept_scheme": {
+                "notes": [],
+                "labels": [],
+                "uri": "urn:x-skosprovider:materials"
+            },
+            "member_of": [],
+            "notes": [],
+            "labels": [
+                {
+                    "type": "prefLabel",
+                    "language": "nl-BE",
+                    "label": "kwartsitisch lithisch materiaal volgens herkomst"
+                }
+            ],
+            "members": [
+                44,
+                45
+            ],
+            "uri": "https://id.erfgoed.net/thesauri/materialen/43",
+            "superordinates": [
+                42
+            ],
+            "infer_concept_relations": true,
+            "type": "collection",
+            "id": 43
+        },
+        {
+            "subordinate_arrays": [],
+            "concept_scheme": {
+                "notes": [],
+                "labels": [],
+                "uri": "urn:x-skosprovider:materials"
+            },
+            "member_of": [],
+            "notes": [
+                {
+                    "note": "Leer is de huid of het vel van een dier, die is gelooid om tegen bederf te beschermen en in droge toestand relatief zacht en soepel te maken.",
+                    "type": "definition",
+                    "language": "nl-BE"
+                },
+                {
+                    "note": "Nederlandse Art &amp; Architecture Thesaurus, <a href=\"http://browser.aat-ned.nl/\">http://browser.aat-ned.nl/</a>",
+                    "type": "note",
+                    "language": "nl-BE"
+                }
+            ],
+            "labels": [
+                {
+                    "type": "prefLabel",
+                    "language": "nl-BE",
+                    "label": "leer"
+                }
+            ],
+            "narrower": [],
+            "uri": "https://id.erfgoed.net/thesauri/materialen/30",
+            "related": [],
+            "broader": [
+                29
+            ],
+            "type": "concept",
+            "id": 30
+        },
+        {
+            "subordinate_arrays": [43],
+            "concept_scheme": {
+                "notes": [],
+                "labels": [],
+                "uri": "urn:x-skosprovider:materials"
+            },
+            "member_of": [],
+            "notes": [],
+            "labels": [
+                {
+                    "type": "prefLabel",
+                    "language": "nl-BE",
+                    "label": "lithisch materiaal"
+                }
+            ],
+            "narrower": [
+                46
+            ],
+            "uri": "https://id.erfgoed.net/thesauri/materialen/42",
+            "related": [],
+            "broader": [
+                40
+            ],
+            "type": "concept",
+            "id": 42
+        },
+        {
+            "subordinate_arrays": [],
+            "concept_scheme": {
+                "notes": [],
+                "labels": [],
+                "uri": "urn:x-skosprovider:materials"
+            },
+            "member_of": [],
+            "notes": [
+                {
+                    "note": "Te gebruiken voor het zuivere metaalelement met het symbool Pb. Het metaal is zacht, kneedbaar en vaalgrijs van kleur. Ook te gebruiken voor het metaal wanneer het wordt bewerkt en gevormd om, meestal in combinatie met andere stoffen, verscheidene voorwerpen en materialen te maken.",
+                    "type": "definition",
+                    "language": "nl-BE"
+                },
+                {
+                    "note": "Nederlandse Art &amp; Architecture Thesaurus, <a href=\"http://browser.aat-ned.nl/\">http://browser.aat-ned.nl/</a>",
+                    "type": "note",
+                    "language": "nl-BE"
+                }
+            ],
+            "labels": [
+                {
+                    "type": "prefLabel",
+                    "language": "nl-BE",
+                    "label": "lood"
+                }
+            ],
+            "narrower": [],
+            "uri": "https://id.erfgoed.net/thesauri/materialen/16",
+            "related": [],
+            "broader": [
+                8
+            ],
+            "type": "concept",
+            "id": 16
+        },
+        {
+            "subordinate_arrays": [],
+            "concept_scheme": {
+                "notes": [],
+                "labels": [],
+                "uri": "urn:x-skosprovider:materials"
+            },
+            "member_of": [],
+            "notes": [
+                {
+                    "note": "Botmateriaal of been is een combinatie van organisch en/of anorganisch materiaal die hoofdzakelijk bestaat uit collageen en calciumfosfaat; het vormt het geraamte van de meeste gewervelden, waaronder de mens.",
+                    "type": "definition",
+                    "language": "nl-BE"
+                },
+                {
+                    "note": "Nederlandse Art &amp; Architecture Thesaurus, <a href=\"http://browser.aat-ned.nl/\">http://browser.aat-ned.nl/</a>",
+                    "type": "note",
+                    "language": "nl-BE"
+                }
+            ],
+            "labels": [
+                {
+                    "type": "prefLabel",
+                    "language": "nl-BE",
+                    "label": "menselijk botmateriaal"
+                }
+            ],
+            "narrower": [],
+            "uri": "https://id.erfgoed.net/thesauri/materialen/26",
+            "related": [],
+            "broader": [
+                24
+            ],
+            "type": "concept",
+            "id": 26
+        },
+        {
+            "subordinate_arrays": [],
+            "concept_scheme": {
+                "notes": [],
+                "labels": [],
+                "uri": "urn:x-skosprovider:materials"
+            },
+            "member_of": [13],
+            "notes": [
+                {
+                    "note": "Messing is een legering van koper en zink, meestal met koper als het voornaamste element en met zink als maximaal 40% van het gewicht.",
+                    "type": "definition",
+                    "language": "nl-BE"
+                },
+                {
+                    "note": "Nederlandse Art &amp; Architecture Thesaurus, <a href=\"http://browser.aat-ned.nl/\">http://browser.aat-ned.nl/</a>",
+                    "type": "note",
+                    "language": "nl-BE"
+                }
+            ],
+            "labels": [
+                {
+                    "type": "prefLabel",
+                    "language": "nl-BE",
+                    "label": "messing"
+                }
+            ],
+            "narrower": [],
+            "uri": "https://id.erfgoed.net/thesauri/materialen/15",
+            "related": [],
+            "broader": [],
+            "type": "concept",
+            "id": 15
+        },
+        {
+            "subordinate_arrays": [],
+            "concept_scheme": {
+                "notes": [],
+                "labels": [],
+                "uri": "urn:x-skosprovider:materials"
+            },
+            "member_of": [
+                0
+            ],
+            "notes": [
+                {
+                    "note": "Metaal omvat een grote groep stoffen die meestal een kenmerkende glans vertonen. Het zijn goede geleiders van elektriciteit en warmte, ze zijn ondoorschijnend, kunnen smelten en zijn meestal pletbaar of kneedbaar.",
+                    "type": "definition",
+                    "language": "nl-BE"
+                },
+                {
+                    "note": "Nederlandse Art &amp; Architecture Thesaurus, <a href=\"http://browser.aat-ned.nl/\">http://browser.aat-ned.nl/</a>",
+                    "type": "note",
+                    "language": "nl-BE"
+                }
+            ],
+            "labels": [
+                {
+                    "type": "prefLabel",
+                    "language": "nl-BE",
+                    "label": "metaal"
+                }
+            ],
+            "narrower": [
+                9,
+                11,
+                12,
+                16,
+                17,
+                18,
+                19,
+                48
+            ],
+            "uri": "https://id.erfgoed.net/thesauri/materialen/8",
+            "related": [],
+            "broader": [],
+            "type": "concept",
+            "id": 8
+        },
+        {
+            "subordinate_arrays": [],
+            "concept_scheme": {
+                "notes": [],
+                "labels": [],
+                "uri": "urn:x-skosprovider:materials"
+            },
+            "member_of": [],
+            "notes": [
+                {
+                    "note": "Natuursteen is een term die wordt gebruik voor gesteenten die in de natuur worden aangetroffen en die, na eventuele bewerking, kunnen dienen als bouwmateriaal. Hieronder vallen steensoorten zoals graniet, tefriet, Doornikse kalksteen, zandsteen, Balegemse kalkzandsteen, Gobertangesteen, arduin (blauwe hardsteen), ijzerzandsteen, veldsteen, Ypresiaanse nummilietenkalksteen, Avendersteen, schieffer, enz...",
+                    "type": "definition",
+                    "language": "nl-BE"
+                },
+                {
+                    "note": "1) Nederlandse Art &amp; Architecture Thesaurus, <a href=\"http://browser.aat-ned.nl/\">http://browser.aat-ned.nl/</a> 2) VIOE",
+                    "type": "note",
+                    "language": "nl-BE"
+                }
+            ],
+            "labels": [
+                {
+                    "type": "prefLabel",
+                    "language": "nl-BE",
+                    "label": "natuursteen"
+                }
+            ],
+            "narrower": [],
+            "uri": "https://id.erfgoed.net/thesauri/materialen/41",
+            "related": [],
+            "broader": [
+                40
+            ],
+            "type": "concept",
+            "id": 41
+        },
+        {
+            "subordinate_arrays": [],
+            "concept_scheme": {
+                "notes": [],
+                "labels": [],
+                "uri": "urn:x-skosprovider:materials"
+            },
+            "member_of": [
+                0
+            ],
+            "notes": [
+                {
+                    "note": "Organisch materiaal is materiaal dat koolstof bevat, inclusief de materialen die afkomstig zijn van levende organismen.",
+                    "type": "definition",
+                    "language": "nl-BE"
+                },
+                {
+                    "note": "Nederlandse Art &amp; Architecture Thesaurus, <a href=\"http://browser.aat-ned.nl/\">http://browser.aat-ned.nl/</a>",
+                    "type": "note",
+                    "language": "nl-BE"
+                }
+            ],
+            "labels": [
+                {
+                    "type": "prefLabel",
+                    "language": "nl-BE",
+                    "label": "organisch materiaal"
+                }
+            ],
+            "narrower": [
+                23,
+                24,
+                27,
+                28,
+                29,
+                32
+            ],
+            "uri": "https://id.erfgoed.net/thesauri/materialen/21",
+            "related": [],
+            "broader": [],
+            "type": "concept",
+            "id": 21
+        },
+        {
+            "subordinate_arrays": [],
+            "concept_scheme": {
+                "notes": [],
+                "labels": [],
+                "uri": "urn:x-skosprovider:materials"
+            },
+            "member_of": [],
+            "notes": [
+                {
+                    "note": "Pijpaarde is een bepaalde soort fijne, witbakkende klei die gebruikt werd voor het maken van pijpen, beeldjes, fijn aardewerk enz...",
+                    "type": "definition",
+                    "language": "nl-BE"
+                },
+                {
+                    "note": "VIOE",
+                    "type": "note",
+                    "language": "nl-BE"
+                }
+            ],
+            "labels": [
+                {
+                    "type": "prefLabel",
+                    "language": "nl-BE",
+                    "label": "pijpaarde"
+                }
+            ],
+            "narrower": [],
+            "uri": "https://id.erfgoed.net/thesauri/materialen/2",
+            "related": [],
+            "broader": [
+                1
+            ],
+            "type": "concept",
+            "id": 2
+        },
+        {
+            "subordinate_arrays": [],
+            "concept_scheme": {
+                "notes": [],
+                "labels": [],
+                "uri": "urn:x-skosprovider:materials"
+            },
+            "member_of": [],
+            "notes": [],
+            "labels": [
+                {
+                    "type": "prefLabel",
+                    "language": "nl-BE",
+                    "label": "plantaardig materiaal"
+                }
+            ],
+            "narrower": [
+                33,
+                35,
+                36,
+                37
+            ],
+            "uri": "https://id.erfgoed.net/thesauri/materialen/32",
+            "related": [],
+            "broader": [
+                21
+            ],
+            "type": "concept",
+            "id": 32
+        },
+        {
+            "subordinate_arrays": [],
+            "concept_scheme": {
+                "notes": [],
+                "labels": [],
+                "uri": "urn:x-skosprovider:materials"
+            },
+            "member_of": [
+                0
+            ],
+            "notes": [
+                {
+                    "note": "Pleister verwijst naar zacht, plastisch materiaal dat kan worden uitgerold of uitgestreken op een muur, plafond of ander oppervlak waarop het vervolgens verhardt. In de context van kunst en architectuur verwijst het meestal specifiek naar een mengsel van water, kalk en zand, vaak in combinatie met andere materialen zoals dierenhaar, waardoor het materiaal meer kracht, textuur en - als het oppervlak daarna wordt geschilderd - poreusheid krijgt.",
+                    "type": "definition",
+                    "language": "nl-BE"
+                },
+                {
+                    "note": "Art &amp; Architecture Thesaurus",
+                    "type": "note",
+                    "language": "nl-BE"
+                }
+            ],
+            "labels": [
+                {
+                    "type": "prefLabel",
+                    "language": "nl-BE",
+                    "label": "pleister"
+                }
+            ],
+            "narrower": [],
+            "uri": "https://id.erfgoed.net/thesauri/materialen/50",
+            "related": [],
+            "broader": [],
+            "type": "concept",
+            "id": 50
+        },
+        {
+            "subordinate_arrays": [],
+            "concept_scheme": {
+                "notes": [],
+                "labels": [],
+                "uri": "urn:x-skosprovider:materials"
+            },
+            "member_of": [],
+            "notes": [
+                {
+                    "note": "Porselein verwijst naar een bepaald soort hardgebakken aardewerk van vuurbestendige witte klei, kaolien, waaraan veldspaat en kwarts worden toegevoegd.",
+                    "type": "definition",
+                    "language": "nl-BE"
+                },
+                {
+                    "note": "VIOE",
+                    "type": "note",
+                    "language": "nl-BE"
+                }
+            ],
+            "labels": [
+                {
+                    "type": "prefLabel",
+                    "language": "nl-BE",
+                    "label": "porselein"
+                }
+            ],
+            "narrower": [],
+            "uri": "https://id.erfgoed.net/thesauri/materialen/5",
+            "related": [],
+            "broader": [
+                1
+            ],
+            "type": "concept",
+            "id": 5
+        },
+        {
+            "subordinate_arrays": [],
+            "concept_scheme": {
+                "notes": [],
+                "labels": [],
+                "uri": "urn:x-skosprovider:materials"
+            },
+            "member_of": [
+                0
+            ],
+            "notes": [
+                {
+                    "note": "De het uitwendig skelet van een weekdier samengesteld uit kalk of andere mineralen.",
+                    "type": "definition",
+                    "language": "nl-BE"
+                }
+            ],
+            "labels": [
+                {
+                    "type": "prefLabel",
+                    "language": "nl-BE",
+                    "label": "schelp"
+                }
+            ],
+            "narrower": [],
+            "uri": "https://id.erfgoed.net/thesauri/materialen/31",
+            "related": [],
+            "broader": [],
+            "type": "concept",
+            "id": 31
+        },
+        {
+            "subordinate_arrays": [],
+            "concept_scheme": {
+                "notes": [],
+                "labels": [],
+                "uri": "urn:x-skosprovider:materials"
+            },
+            "member_of": [],
+            "notes": [
+                {
+                    "note": "Een fijnkorrelig, compact sedimentair gesteente dat bestaat uit kwartskristallen.",
+                    "type": "definition",
+                    "language": "nl-BE"
+                },
+                {
+                    "note": "Nederlandse Art &amp; Architecture Thesaurus, <a href=\"http://browser.aat-ned.nl/\">http://browser.aat-ned.nl/</a>",
+                    "type": "note",
+                    "language": "nl-BE"
+                }
+            ],
+            "labels": [
+                {
+                    "type": "prefLabel",
+                    "language": "nl-BE",
+                    "label": "silex"
+                },
+                {
+                    "type": "altLabel",
+                    "language": "nl-BE",
+                    "label": "vuursteen"
+                }
+            ],
+            "narrower": [],
+            "uri": "https://id.erfgoed.net/thesauri/materialen/46",
+            "related": [],
+            "broader": [
+                42
+            ],
+            "type": "concept",
+            "id": 46
+        },
+        {
+            "subordinate_arrays": [],
+            "concept_scheme": {
+                "notes": [],
+                "labels": [],
+                "uri": "urn:x-skosprovider:materials"
+            },
+            "member_of": [],
+            "notes": [
+                {
+                    "note": "Staal is een legering van ijzer en koolstof.",
+                    "type": "definition",
+                    "language": "nl-BE"
+                }
+            ],
+            "labels": [
+                {
+                    "type": "prefLabel",
+                    "language": "nl-BE",
+                    "label": "staal"
+                }
+            ],
+            "narrower": [],
+            "uri": "https://id.erfgoed.net/thesauri/materialen/17",
+            "related": [],
+            "broader": [
+                8
+            ],
+            "type": "concept",
+            "id": 17
+        },
+        {
+            "subordinate_arrays": [],
+            "concept_scheme": {
+                "notes": [],
+                "labels": [],
+                "uri": "urn:x-skosprovider:materials"
+            },
+            "member_of": [
+                0
+            ],
+            "notes": [
+                {
+                    "note": "Steen is een harde stof met een minerale samenstelling.",
+                    "type": "definition",
+                    "language": "nl-BE"
+                }
+            ],
+            "labels": [
+                {
+                    "type": "prefLabel",
+                    "language": "nl-BE",
+                    "label": "steen"
+                }
+            ],
+            "narrower": [
+                41,
+                42
+            ],
+            "uri": "https://id.erfgoed.net/thesauri/materialen/40",
+            "related": [],
+            "broader": [],
+            "type": "concept",
+            "id": 40
+        },
+        {
+            "subordinate_arrays": [],
+            "concept_scheme": {
+                "notes": [],
+                "labels": [],
+                "uri": "urn:x-skosprovider:materials"
+            },
+            "member_of": [],
+            "notes": [
+                {
+                    "note": "Steengoed is een soort aardewerk dat gemaakt is van klei en smeltbaar gesteente. Het materiaal wordt zolang gebakken tot er gedeeltelijke verglazing optreedt, waardoor het materiaal waterdicht wordt.",
+                    "type": "definition",
+                    "language": "nl-BE"
+                },
+                {
+                    "note": "Nederlandse Art &amp; Architecture Thesaurus, <a href=\"http://browser.aat-ned.nl/\">http://browser.aat-ned.nl/</a>",
+                    "type": "note",
+                    "language": "nl-BE"
+                }
+            ],
+            "labels": [
+                {
+                    "type": "prefLabel",
+                    "language": "nl-BE",
+                    "label": "steengoed"
+                }
+            ],
+            "narrower": [],
+            "uri": "https://id.erfgoed.net/thesauri/materialen/6",
+            "related": [],
+            "broader": [
+                1
+            ],
+            "type": "concept",
+            "id": 6
+        },
+        {
+            "subordinate_arrays": [],
+            "concept_scheme": {
+                "notes": [],
+                "labels": [],
+                "uri": "urn:x-skosprovider:materials"
+            },
+            "member_of": [],
+            "notes": [
+                {
+                    "note": "Textiel is een materiaal dat tot stand is gekomen door middel van weven, vervilten, knopen, twijnen of andersoortige bewerking van natuurlijke of synthetische vezels zodanig dat zij bijeenblijven.",
+                    "type": "definition",
+                    "language": "nl-BE"
+                },
+                {
+                    "note": "Nederlandse Art &amp; Architecture Thesaurus, <a href=\"http://browser.aat-ned.nl/\">http://browser.aat-ned.nl/</a>",
+                    "type": "note",
+                    "language": "nl-BE"
+                }
+            ],
+            "labels": [
+                {
+                    "type": "prefLabel",
+                    "language": "nl-BE",
+                    "label": "textiel"
+                }
+            ],
+            "narrower": [],
+            "uri": "https://id.erfgoed.net/thesauri/materialen/37",
+            "related": [],
+            "broader": [
+                32
+            ],
+            "type": "concept",
+            "id": 37
+        },
+        {
+            "subordinate_arrays": [],
+            "concept_scheme": {
+                "notes": [],
+                "labels": [],
+                "uri": "urn:x-skosprovider:materials"
+            },
+            "member_of": [],
+            "notes": [
+                {
+                    "note": "Te gebruiken voor het zuivere metaalelement met het symbool Sn. Het zilverachtig witte metaal is zacht en buigzaam. Ook te gebruiken voor dit metaal wanneer het wordt bewerkt en gevormd om, meestal in combinatie met andere stoffen, diverse voorwerpen en materialen te maken.",
+                    "type": "definition",
+                    "language": "nl-BE"
+                },
+                {
+                    "note": "Nederlandse Art &amp; Architecture Thesaurus, <a href=\"http://browser.aat-ned.nl/\">http://browser.aat-ned.nl/</a>",
+                    "type": "note",
+                    "language": "nl-BE"
+                }
+            ],
+            "labels": [
+                {
+                    "type": "prefLabel",
+                    "language": "nl-BE",
+                    "label": "tin"
+                }
+            ],
+            "narrower": [],
+            "uri": "https://id.erfgoed.net/thesauri/materialen/18",
+            "related": [],
+            "broader": [
+                8
+            ],
+            "type": "concept",
+            "id": 18
+        },
+        {
+            "subordinate_arrays": [],
+            "concept_scheme": {
+                "notes": [],
+                "labels": [],
+                "uri": "urn:x-skosprovider:materials"
+            },
+            "member_of": [43],
+            "notes": [
+                {
+                    "note": "Wommersomkwartsiet vertoont een textuur van hoekige kwartskorrels in een fijnkorrelig kwartscement ingebed. Deze gesteentesoort komt schijnbaar alleen voor in Wommersom, nabij Tienen. Het vertoont enige gelijkenis met silex en werd alsdusdanig ook gebruikt om prehistorische werktuigen te maken.",
+                    "type": "definition",
+                    "language": "nl-BE"
+                },
+                {
+                    "note": "Gullentops F. &amp; Wouters L., Delfstoffen in Vlaanderen, Ministerie van de Vlaamse gemeenschap, Departement EWBL.",
+                    "type": "note",
+                    "language": "nl-BE"
+                }
+            ],
+            "labels": [
+                {
+                    "type": "prefLabel",
+                    "language": "nl-BE",
+                    "label": "wommersomkwartsiet"
+                }
+            ],
+            "narrower": [],
+            "uri": "https://id.erfgoed.net/thesauri/materialen/45",
+            "related": [],
+            "broader": [],
+            "type": "concept",
+            "id": 45
+        },
+        {
+            "subordinate_arrays": [],
+            "concept_scheme": {
+                "notes": [],
+                "labels": [],
+                "uri": "urn:x-skosprovider:materials"
+            },
+            "member_of": [],
+            "notes": [
+                {
+                    "note": "Te gebruiken voor het zuivere metaalelement met het symbool Ag. Het metaal is smeedbaar, vervormbaar en wit van kleur met een kenmerkende glans en wordt als edel beschouwd. Ook te gebruiken voor dit metaal wanneer het wordt bewerkt en gevormd om, meestal in combinatie met andere stoffen, diverse voorwerpen en materialen te maken.",
+                    "type": "definition",
+                    "language": "nl-BE"
+                },
+                {
+                    "note": "Nederlandse Art &amp; Architecture Thesaurus, <a href=\"http://browser.aat-ned.nl/\">http://browser.aat-ned.nl/</a>",
+                    "type": "note",
+                    "language": "nl-BE"
+                }
+            ],
+            "labels": [
+                {
+                    "type": "prefLabel",
+                    "language": "nl-BE",
+                    "label": "zilver"
+                }
+            ],
+            "narrower": [],
+            "uri": "https://id.erfgoed.net/thesauri/materialen/19",
+            "related": [],
+            "broader": [
+                8
+            ],
+            "type": "concept",
+            "id": 19
+        },
+        {
+            "concept_scheme": {
+                "notes": [],
+                "labels": [],
+                "uri": "urn:x-skosprovider:materials"
+            },
+            "member_of": [],
+            "notes": [],
+            "labels": [
+                {
+                    "type": "prefLabel",
+                    "language": "nl-BE",
+                    "label": "Materiaal"
+                }
+            ],
+            "uri": "https://id.erfgoed.net/thesauri/materialen/0",
+            "members": [
+                1,
+                7,
+                8,
+                20,
+                21,
+                31,
+                38,
+                40,
+                49,
+                50
+            ],
+            "superordinates": [],
+            "type": "collection",
+            "id": 0
+        },
+        {
+            "concept_scheme": {
+                "notes": [],
+                "labels": [],
+                "uri": "urn:x-skosprovider:materials"
+            },
+            "member_of": [],
+            "labels": [
+                {
+                    "type": "prefLabel",
+                    "language": "nl-BE",
+                    "label": "beton naar versterking"
+                }
+            ],
+            "uri": "https://id.erfgoed.net/thesauri/materialen/68",
+            "members": [69],
+            "superordinates": [38],
+            "type": "collection",
+            "infer_concept_relations": "True",
+            "id": 68
+        },
+        {
+            "concept_scheme": {
+                "notes": [],
+                "labels": [],
+                "uri": "urn:x-skosprovider:materials"
+            },
+            "member_of": [68],
+            "labels": [
+                {
+                    "type": "prefLabel",
+                    "language": "nl-BE",
+                    "label": "beton naar bewapening"
+                }
+            ],
+            "uri": "https://id.erfgoed.net/thesauri/materialen/69",
+            "members": [39, 70],
+            "superordinates": [],
+            "type": "collection",
+            "infer_concept_relations": "True",
+            "id": 69
+        },
+        {
+            "subordinate_arrays": [],
+            "concept_scheme": {
+                "notes": [],
+                "labels": [],
+                "uri": "urn:x-skosprovider:materials"
+            },
+            "member_of": [69],
+            "notes": [
+                {
+                    "note": "Ongewapend beton is een gewapend beton dat onschadelijk gemaakt werd met een tijger.",
+                    "type": "definition",
+                    "language": "nl-BE"
+                }
+            ],
+            "labels": [
+                {
+                    "type": "prefLabel",
+                    "language": "nl-BE",
+                    "label": "ongewapend beton"
+                }
+            ],
+            "narrower": [],
+            "uri": "https://id.erfgoed.net/thesauri/materialen/70",
+            "related": [],
+            "broader": [],
+            "type": "concept",
+            "id": 70
+        }
+    ]
+}

--- a/tests/data/schemes.xml
+++ b/tests/data/schemes.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+>
+  <rdf:Description rdf:about="https://id.erfgoed.net/toepassingen">
+    <skos:prefLabel xml:lang="nl">Toepassingen</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://id.erfgoed.net/applicaties">
+    <skos:prefLabel xml:lang="nl">Applicaties</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://id.erfgoed.net/toepassingen/3">
+    <skos:prefLabel xml:lang="nl">Premies</skos:prefLabel>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:inScheme>https://id.erfgoed.net/toepassingen</skos:inScheme>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://id.erfgoed.net/toepassingen/1">
+    <skos:prefLabel xml:lang="nl">Adviezen</skos:prefLabel>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:inScheme>https://id.erfgoed.net/toepassingen</skos:inScheme>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://id.erfgoed.net/applicaties/2">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<skos:prefLabel xml:lang="nl">Beschermingen</skos:prefLabel>
+	<skos:inScheme>https://id.erfgoed.net/applicaties</skos:inScheme>
+  </rdf:Description>
+</rdf:RDF>

--- a/tests/data/simple_turtle_products
+++ b/tests/data/simple_turtle_products
@@ -1,0 +1,55 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix ex: <http://www.products.com/>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix dc: <http://purl.org/dc/elements/1.1/>.
+@prefix ex-prop: <http://www.products.com/properties/>.
+
+ex:Scheme rdf:type owl:Class;
+  a skos:ConceptScheme;
+  skos:prefLabel "Products"@en;
+  dct:language "en";
+  dct:language "nl";
+  dc:language "BE-nl-Latn".
+
+ex:Stuff rdf:type owl:Class;
+  a skos:Collection;
+  skos:inScheme ex:Scheme;
+  skos:prefLabel "Stuff people can buy"@en;
+  skos:altLabel "Things you can find in a store"@en;
+  skos:altLabel "Producten uit de winkel"@nl;
+  skos:member ex:Product;
+  skos:member ex:Perfume;
+  skos:member ex:Jewellery.
+
+ex:Product rdf:type owl:Class;
+  a skos:Concept;
+  skos:inScheme ex:Scheme;
+  skos:prefLabel "Product"@en;
+  skos:altLabel "Produkt"@nl;
+  skos:altLabel "Produkt"@nl;
+  skos:narrower ex:Jewellery;
+  skos:narrower ex:Perfume;
+  skos:notation "PROD-001";
+  ex-prop:internalCode "P1".
+
+ex:Jewellery rdf:type owl:Class;
+  a skos:Concept;
+  skos:inScheme ex:Scheme;
+  skos:prefLabel "Jewellery";
+  skos:altLabel "Jewelry"@en;
+  skos:altLabel "Jewelery"@en;
+  skos:broader ex:Product;
+  skos:related ex:Perfume;
+  skos:note "Everything on your body that reflects when the sun shines"@en;
+  skos:example "A watch".
+  
+ex:Perfume rdf:type owl:Class;
+  a skos:Concept;
+  skos:inScheme ex:Scheme;
+  skos:prefLabel "Perfume";
+  skos:altLabel "Parfum"@nl;
+  skos:altLabel "Reukwaar"@nl;
+  skos:broader ex:Product;
+  skos:related ex:Jewellery.

--- a/tests/data/toepassingen.xml
+++ b/tests/data/toepassingen.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+>
+  <rdf:Description rdf:about="https://id.erfgoed.net/toepassingen/3">
+    <skos:prefLabel xml:lang="nl">Premies</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <dc:identifier rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</dc:identifier>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://id.erfgoed.net/toepassingen/1">
+    <skos:prefLabel xml:lang="nl">Adviezen</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <dc:identifier rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</dc:identifier>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://id.erfgoed.net/toepassingen/2">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:prefLabel xml:lang="nl">Beschermingen</skos:prefLabel>
+    <dc:identifier rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</dc:identifier>
+  </rdf:Description>
+</rdf:RDF>

--- a/tests/data/trees.xml
+++ b/tests/data/trees.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF
+    xmlns:dcterms="http://purl.org/dc/terms/"
+    xmlns:dc="http://purl.org/dc/elements/1.1/"
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+>
+  <rdf:Description rdf:about="http://id.trees.org/1">
+    <skos:inScheme rdf:resource="urn:x-skosprovider:tree"/>
+    <dcterms:identifier>1</dcterms:identifier>
+    <skos:prefLabel xml:lang="en">The Larch</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:definition xml:lang="en">A type of tree.</skos:definition>
+    <skos:definition rdf:datatype="http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"><![CDATA[<p xml:lang="nl">Een soort boom.</p>]]></skos:definition>
+    <skos:prefLabel xml:lang="nl">De Lariks</skos:prefLabel>
+    <dcterms:source>
+        <dcterms:BibliographicResource>
+            <dcterms:bibliographicCitation>Monthy Python. Episode Three: How to recognise different types of trees from quite a long way away.</dcterms:bibliographicCitation>
+        </dcterms:BibliographicResource>
+    </dcterms:source>
+    <skos:exactMatch>https://id.erfgoed.net/thesauri/soorten/666</skos:exactMatch>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://id.trees.org/3">
+    <dcterms:identifier rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</dcterms:identifier>
+    <skos:member rdf:resource="http://id.trees.org/2"/>
+    <skos:prefLabel xml:lang="nl">Bomen per soort</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Collection"/>
+    <skos:inScheme rdf:resource="urn:x-skosprovider:tree"/>
+    <skos:member rdf:resource="http://id.trees.org/1"/>
+    <skos:prefLabel xml:lang="en">Trees by species</skos:prefLabel>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://id.trees.org/2">
+    <skos:altLabel xml:lang="nl">De Paardekastanje</skos:altLabel>
+    <skos:inScheme rdf:resource="urn:x-skosprovider:tree"/>
+    <skos:altLabel xml:lang="fr">la châtaigne</skos:altLabel>
+    <skos:prefLabel xml:lang="en">The Chestnut</skos:prefLabel>
+    <skos:definition rdf:datatype="http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"><![CDATA[<p xml:lang="en">A different type of tree.</p>]]></skos:definition>
+    <skos:definition rdf:datatype="http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"><![CDATA[Een ander soort boom.]]></skos:definition>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <dc:identifier>2</dc:identifier>
+    <dcterms:source>
+        <dcterms:BibliographicResource>
+            <dcterms:bibliographicCitation rdf:datatype="http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"><![CDATA[<strong>Monthy Python.</strong> Episode Three: How to recognise different types of trees from quite a long way away.]]></dcterms:bibliographicCitation>
+        </dcterms:BibliographicResource>
+    </dcterms:source>
+    <skos:closeMatch>https://id.erfgoed.net/thesauri/soorten/85</skos:closeMatch>
+  </rdf:Description>
+</rdf:RDF>

--- a/tests/data/vlaardingencultuur.rdf
+++ b/tests/data/vlaardingencultuur.rdf
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF
+   xmlns:dcterms="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+>
+  <rdf:Description rdf:about="https://id.erfgoed.net/thesauri/stijlen_en_culturen/113">
+    <dcterms:source>
+        <dcterms:BibliographicResource>
+            <dcterms:bibliographicCitation>
+                <![CDATA[1) Louwe Kooijmans L., van den Broecke P.W., Fokkens H. en van Gijn A. (eds.), 2005, Nederland in de prehistorie, Amsterdam. 2) Deeben J. e.a. (red.) 2005, De Steentijd van Nederland, Zutphen.]]>
+            </dcterms:bibliographicCitation>
+        </dcterms:BibliographicResource>
+    </dcterms:source>
+    <dcterms:identifier rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">113</dcterms:identifier>
+    <skos:definition rdf:datatype="http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML">
+        <![CDATA[<p xml:lang="nl">Deze cultuur komt voornamelijk voor in <em>Nederland</em> (langsheen kust), maar kent ook enkele sites in België. Deze cultuur kent mogelijk zijn oorsprong in de hazendonkgroep en de swifterbantcultuur (technologische overeenkomsten). Ze heeft echter wel eigen aardewerkvormen en versiering ontbreekt. Deze traditie kan gedateerd worden tussen 3400 en 2500 v.Chr.</p>]]>
+    </skos:definition>
+    <skos:prefLabel xml:lang="nl">vlaardingencultuur</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://id.erfgoed.net/thesauri/stijlen_en_culturen"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://id.erfgoed.net/thesauri/stijlen_en_culturen">
+    <skos:prefLabel xml:lang="nl">Stijlen en Culturen</skos:prefLabel>
+    <skos:prefLabel xml:lang="en">Styles and Cultures</skos:prefLabel>
+  </rdf:Description>
+</rdf:RDF>

--- a/tests/data/waarde_en_besluit_types.ttl
+++ b/tests/data/waarde_en_besluit_types.ttl
@@ -1,0 +1,448 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix skos-thes: <http://purl.org/iso25964/skos-thes#> .
+@prefix void: <http://rdfs.org/ns/void#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://id.erfgoed.net/thesauri/besluittypes/11> a skos:Collection ;
+    dcterms:identifier 11 ;
+    void:inDataset <https://id.erfgoed.net/datasets/thesauri/besluittypes> ;
+    skos:inScheme <https://id.erfgoed.net/thesauri/besluittypes> ;
+    skos:member <https://id.erfgoed.net/thesauri/besluittypes/12>,
+        <https://id.erfgoed.net/thesauri/besluittypes/13>,
+        <https://id.erfgoed.net/thesauri/besluittypes/14>,
+        <https://id.erfgoed.net/thesauri/besluittypes/15>,
+        <https://id.erfgoed.net/thesauri/besluittypes/16>,
+        <https://id.erfgoed.net/thesauri/besluittypes/17>,
+        <https://id.erfgoed.net/thesauri/besluittypes/18>,
+        <https://id.erfgoed.net/thesauri/besluittypes/19>,
+        <https://id.erfgoed.net/thesauri/besluittypes/20>,
+        <https://id.erfgoed.net/thesauri/besluittypes/88>,
+        <https://id.erfgoed.net/thesauri/besluittypes/90> ;
+    skos:prefLabel "besluiten naar rechtsgevolg"@nl-BE .
+
+<https://id.erfgoed.net/thesauri/besluittypes/2> a skos:Collection ;
+    dcterms:identifier 2 ;
+    void:inDataset <https://id.erfgoed.net/datasets/thesauri/besluittypes> ;
+    skos:inScheme <https://id.erfgoed.net/thesauri/besluittypes> ;
+    skos:member <https://id.erfgoed.net/thesauri/besluittypes/10>,
+        <https://id.erfgoed.net/thesauri/besluittypes/3>,
+        <https://id.erfgoed.net/thesauri/besluittypes/4>,
+        <https://id.erfgoed.net/thesauri/besluittypes/5>,
+        <https://id.erfgoed.net/thesauri/besluittypes/6>,
+        <https://id.erfgoed.net/thesauri/besluittypes/7>,
+        <https://id.erfgoed.net/thesauri/besluittypes/8>,
+        <https://id.erfgoed.net/thesauri/besluittypes/89>,
+        <https://id.erfgoed.net/thesauri/besluittypes/9> ;
+    skos:prefLabel "besluiten naar uitvaardiger"@nl-BE .
+
+<https://id.erfgoed.net/thesauri/besluittypes/54> a skos:Concept ;
+    dcterms:identifier 54 ;
+    void:inDataset <https://id.erfgoed.net/datasets/thesauri/besluittypes> ;
+    skos:broader <https://id.erfgoed.net/thesauri/besluittypes/14> ;
+    skos:inScheme <https://id.erfgoed.net/thesauri/besluittypes> ;
+    skos:prefLabel "voorlopige wijzigingsbesluiten"@nl-BE .
+
+<https://id.erfgoed.net/thesauri/besluittypes/87> a skos:Concept ;
+    dcterms:identifier 87 ;
+    void:inDataset <https://id.erfgoed.net/datasets/thesauri/besluittypes> ;
+    skos:broader <https://id.erfgoed.net/thesauri/besluittypes/15> ;
+    skos:inScheme <https://id.erfgoed.net/thesauri/besluittypes> ;
+    skos:prefLabel "voorlopige opheffingsbesluiten"@nl-BE .
+
+<https://id.erfgoed.net/thesauri/besluittypes/10> a skos:Concept ;
+    dcterms:identifier 10 ;
+    void:inDataset <https://id.erfgoed.net/datasets/thesauri/besluittypes> ;
+    skos:inScheme <https://id.erfgoed.net/thesauri/besluittypes> ;
+    skos:prefLabel "arresten Raad van State"@nl-BE .
+
+<https://id.erfgoed.net/thesauri/besluittypes/12> a skos:Concept ;
+    dcterms:identifier 12 ;
+    void:inDataset <https://id.erfgoed.net/datasets/thesauri/besluittypes> ;
+    skos:altLabel "besluiten tot ontwerp van lijst"@nl-BE ;
+    skos:inScheme <https://id.erfgoed.net/thesauri/besluittypes> ;
+    skos:prefLabel "voorlopige beschermingsbesluiten"@nl-BE .
+
+<https://id.erfgoed.net/thesauri/besluittypes/13> a skos:Concept ;
+    dcterms:identifier 13 ;
+    void:inDataset <https://id.erfgoed.net/datasets/thesauri/besluittypes> ;
+    skos:inScheme <https://id.erfgoed.net/thesauri/besluittypes> ;
+    skos:prefLabel "definitieve beschermingsbesluiten"@nl-BE .
+
+<https://id.erfgoed.net/thesauri/besluittypes/16> a skos:Concept ;
+    dcterms:identifier 16 ;
+    void:inDataset <https://id.erfgoed.net/datasets/thesauri/besluittypes> ;
+    skos:inScheme <https://id.erfgoed.net/thesauri/besluittypes> ;
+    skos:prefLabel "intrekkingsbesluiten"@nl-BE .
+
+<https://id.erfgoed.net/thesauri/besluittypes/17> a skos:Concept ;
+    dcterms:identifier 17 ;
+    void:inDataset <https://id.erfgoed.net/datasets/thesauri/besluittypes> ;
+    skos:inScheme <https://id.erfgoed.net/thesauri/besluittypes> ;
+    skos:prefLabel "schrappingsbesluiten"@nl-BE .
+
+<https://id.erfgoed.net/thesauri/besluittypes/18> a skos:Concept ;
+    dcterms:identifier 18 ;
+    void:inDataset <https://id.erfgoed.net/datasets/thesauri/besluittypes> ;
+    skos:inScheme <https://id.erfgoed.net/thesauri/besluittypes> ;
+    skos:prefLabel "besluiten tot termijnverlenging"@nl-BE .
+
+<https://id.erfgoed.net/thesauri/besluittypes/19> a skos:Concept ;
+    dcterms:identifier 19 ;
+    void:inDataset <https://id.erfgoed.net/datasets/thesauri/besluittypes> ;
+    skos:inScheme <https://id.erfgoed.net/thesauri/besluittypes> ;
+    skos:prefLabel "verplaatsingsbesluiten"@nl-BE .
+
+<https://id.erfgoed.net/thesauri/besluittypes/20> a skos:Concept ;
+    dcterms:identifier 20 ;
+    void:inDataset <https://id.erfgoed.net/datasets/thesauri/besluittypes> ;
+    skos:inScheme <https://id.erfgoed.net/thesauri/besluittypes> ;
+    skos:prefLabel "nietigverklaringen"@nl-BE .
+
+<https://id.erfgoed.net/thesauri/besluittypes/3> a skos:Concept ;
+    dcterms:identifier 3 ;
+    void:inDataset <https://id.erfgoed.net/datasets/thesauri/besluittypes> ;
+    skos:inScheme <https://id.erfgoed.net/thesauri/besluittypes> ;
+    skos:prefLabel "koninklijke besluiten"@nl-BE .
+
+<https://id.erfgoed.net/thesauri/besluittypes/4> a skos:Concept ;
+    dcterms:identifier 4 ;
+    void:inDataset <https://id.erfgoed.net/datasets/thesauri/besluittypes> ;
+    skos:inScheme <https://id.erfgoed.net/thesauri/besluittypes> ;
+    skos:prefLabel "besluiten secretaris-generaal"@nl-BE .
+
+<https://id.erfgoed.net/thesauri/besluittypes/5> a skos:Concept ;
+    dcterms:identifier 5 ;
+    void:inDataset <https://id.erfgoed.net/datasets/thesauri/besluittypes> ;
+    skos:inScheme <https://id.erfgoed.net/thesauri/besluittypes> ;
+    skos:prefLabel "regentsbesluiten"@nl-BE .
+
+<https://id.erfgoed.net/thesauri/besluittypes/6> a skos:Concept ;
+    dcterms:identifier 6 ;
+    void:inDataset <https://id.erfgoed.net/datasets/thesauri/besluittypes> ;
+    skos:inScheme <https://id.erfgoed.net/thesauri/besluittypes> ;
+    skos:prefLabel "koninklijke prins-besluiten"@nl-BE .
+
+<https://id.erfgoed.net/thesauri/besluittypes/7> a skos:Concept ;
+    dcterms:identifier 7 ;
+    void:inDataset <https://id.erfgoed.net/datasets/thesauri/besluittypes> ;
+    skos:inScheme <https://id.erfgoed.net/thesauri/besluittypes> ;
+    skos:prefLabel "besluiten Vlaamse Executieve"@nl-BE .
+
+<https://id.erfgoed.net/thesauri/besluittypes/8> a skos:Concept ;
+    dcterms:identifier 8 ;
+    void:inDataset <https://id.erfgoed.net/datasets/thesauri/besluittypes> ;
+    skos:inScheme <https://id.erfgoed.net/thesauri/besluittypes> ;
+    skos:prefLabel "besluiten Vlaamse Regering"@nl-BE .
+
+<https://id.erfgoed.net/thesauri/besluittypes/88> a skos:Concept ;
+    dcterms:identifier 88 ;
+    void:inDataset <https://id.erfgoed.net/datasets/thesauri/besluittypes> ;
+    skos:inScheme <https://id.erfgoed.net/thesauri/besluittypes> ;
+    skos:prefLabel "vaststellingsbesluiten"@nl-BE .
+
+<https://id.erfgoed.net/thesauri/besluittypes/89> a skos:Concept ;
+    dcterms:identifier 89 ;
+    void:inDataset <https://id.erfgoed.net/datasets/thesauri/besluittypes> ;
+    skos:inScheme <https://id.erfgoed.net/thesauri/besluittypes> ;
+    skos:prefLabel "besluiten administrateur-generaal"@nl-BE .
+
+<https://id.erfgoed.net/thesauri/besluittypes/9> a skos:Concept ;
+    dcterms:identifier 9 ;
+    void:inDataset <https://id.erfgoed.net/datasets/thesauri/besluittypes> ;
+    skos:inScheme <https://id.erfgoed.net/thesauri/besluittypes> ;
+    skos:prefLabel "ministeriële besluiten"@nl-BE .
+
+<https://id.erfgoed.net/thesauri/besluittypes/90> a skos:Concept ;
+    dcterms:identifier 90 ;
+    void:inDataset <https://id.erfgoed.net/datasets/thesauri/besluittypes> ;
+    skos:inScheme <https://id.erfgoed.net/thesauri/besluittypes> ;
+    skos:prefLabel "besluiten tot goedkeuring beheersplan"@nl-BE .
+
+<https://id.erfgoed.net/thesauri/besluittypes/14> a skos:Concept ;
+    dcterms:identifier 14 ;
+    void:inDataset <https://id.erfgoed.net/datasets/thesauri/besluittypes> ;
+    skos:inScheme <https://id.erfgoed.net/thesauri/besluittypes> ;
+    skos:narrower <https://id.erfgoed.net/thesauri/besluittypes/54> ;
+    skos:prefLabel "wijzigingsbesluiten"@nl-BE .
+
+<https://id.erfgoed.net/thesauri/besluittypes/15> a skos:Concept ;
+    dcterms:identifier 15 ;
+    void:inDataset <https://id.erfgoed.net/datasets/thesauri/besluittypes> ;
+    skos:inScheme <https://id.erfgoed.net/thesauri/besluittypes> ;
+    skos:narrower <https://id.erfgoed.net/thesauri/besluittypes/87> ;
+    skos:prefLabel "opheffingsbesluiten"@nl-BE .
+
+<https://id.erfgoed.net/thesauri/besluittypes> a skos:ConceptScheme ;
+    dcterms:identifier "BESLUITTYPES" ;
+    void:inDataset <https://id.erfgoed.net/datasets/thesauri/besluittypes> ;
+    skos:hasTopConcept <https://id.erfgoed.net/thesauri/besluittypes/10>,
+        <https://id.erfgoed.net/thesauri/besluittypes/12>,
+        <https://id.erfgoed.net/thesauri/besluittypes/13>,
+        <https://id.erfgoed.net/thesauri/besluittypes/14>,
+        <https://id.erfgoed.net/thesauri/besluittypes/15>,
+        <https://id.erfgoed.net/thesauri/besluittypes/16>,
+        <https://id.erfgoed.net/thesauri/besluittypes/17>,
+        <https://id.erfgoed.net/thesauri/besluittypes/18>,
+        <https://id.erfgoed.net/thesauri/besluittypes/19>,
+        <https://id.erfgoed.net/thesauri/besluittypes/20>,
+        <https://id.erfgoed.net/thesauri/besluittypes/3>,
+        <https://id.erfgoed.net/thesauri/besluittypes/4>,
+        <https://id.erfgoed.net/thesauri/besluittypes/5>,
+        <https://id.erfgoed.net/thesauri/besluittypes/6>,
+        <https://id.erfgoed.net/thesauri/besluittypes/7>,
+        <https://id.erfgoed.net/thesauri/besluittypes/8>,
+        <https://id.erfgoed.net/thesauri/besluittypes/88>,
+        <https://id.erfgoed.net/thesauri/besluittypes/89>,
+        <https://id.erfgoed.net/thesauri/besluittypes/9>,
+        <https://id.erfgoed.net/thesauri/besluittypes/90> ;
+    skos:prefLabel "Decree types"@en,
+        "Besluit types"@nl .
+
+<https://id.erfgoed.net/thesauri/waardetypes/30> a skos:Collection ;
+    dcterms:identifier 30 ;
+    void:inDataset <https://id.erfgoed.net/datasets/thesauri/waardetypes> ;
+    skos:inScheme <https://id.erfgoed.net/thesauri/waardetypes> ;
+    skos:member <https://id.erfgoed.net/thesauri/waardetypes/31>,
+        <https://id.erfgoed.net/thesauri/waardetypes/32>,
+        <https://id.erfgoed.net/thesauri/waardetypes/33>,
+        <https://id.erfgoed.net/thesauri/waardetypes/34>,
+        <https://id.erfgoed.net/thesauri/waardetypes/35>,
+        <https://id.erfgoed.net/thesauri/waardetypes/36> ;
+    skos:prefLabel "waarden naar historisch gebruik"@nl-BE .
+
+<https://id.erfgoed.net/thesauri/waardetypes/37> a skos:Collection ;
+    dcterms:identifier 37 ;
+    void:inDataset <https://id.erfgoed.net/datasets/thesauri/waardetypes> ;
+    skos:inScheme <https://id.erfgoed.net/thesauri/waardetypes> ;
+    skos:member <https://id.erfgoed.net/thesauri/waardetypes/38>,
+        <https://id.erfgoed.net/thesauri/waardetypes/39>,
+        <https://id.erfgoed.net/thesauri/waardetypes/40>,
+        <https://id.erfgoed.net/thesauri/waardetypes/41>,
+        <https://id.erfgoed.net/thesauri/waardetypes/42>,
+        <https://id.erfgoed.net/thesauri/waardetypes/43>,
+        <https://id.erfgoed.net/thesauri/waardetypes/44>,
+        <https://id.erfgoed.net/thesauri/waardetypes/45>,
+        <https://id.erfgoed.net/thesauri/waardetypes/46>,
+        <https://id.erfgoed.net/thesauri/waardetypes/47>,
+        <https://id.erfgoed.net/thesauri/waardetypes/48>,
+        <https://id.erfgoed.net/thesauri/waardetypes/49>,
+        <https://id.erfgoed.net/thesauri/waardetypes/50> ;
+    skos:prefLabel "waarden naar actueel gebruik"@nl-BE .
+
+<https://id.erfgoed.net/thesauri/waardetypes/31> a skos:Concept ;
+    dcterms:identifier 31 ;
+    void:inDataset <https://id.erfgoed.net/datasets/thesauri/waardetypes> ;
+    skos:inScheme <https://id.erfgoed.net/thesauri/waardetypes> ;
+    skos:prefLabel "sociaal-culturele waarde"@nl-BE ;
+    skos:scopeNote "Bijkomend aspect van gevoelswaarde, bv. als herkenningspunt, symbool. De sociaal-culturele waarde beschrijft maatschappelijke aspecten van het gebied of van een element voor mensen (al dan niet uit de directe omgeving). Het gaat dan bijvoorbeeld om een belangrijke functie in het verleden voor de lokale bevolking, bijvoorbeeld bedevaartoorden (die nog steeds gebruikt worden), bepaalde grote ontginningen of speciale landbouwvormen en ambachten die een belangrijke stempel op het landschap gedrukt hebben. Ook het voorkomen van het gebouw of gebied in specifieke sagen en legendes wordt onder de sociaal-culturele waarde verstaan. Van bovenlokaal niveau zijn vaak de functies voor zorg (landloperskolonies, ziekenhuizen, etc.), de oorlog of voor de herinnering ervan, literatuur, film, etc. Onroerend erfgoed kan ook nu nog een belangrijke sociale- of culturele waarde hebben. Het gaat dan over educatieve (of recreatieve) functies. (bron: document Claartje &amp; interne handleiding Ankerplaatsen)"@nl-BE .
+
+<https://id.erfgoed.net/thesauri/waardetypes/32> a skos:Concept ;
+    dcterms:identifier 32 ;
+    void:inDataset <https://id.erfgoed.net/datasets/thesauri/waardetypes> ;
+    skos:inScheme <https://id.erfgoed.net/thesauri/waardetypes> ;
+    skos:prefLabel "natuurlijke waarde"@nl-BE .
+
+<https://id.erfgoed.net/thesauri/waardetypes/33> a skos:Concept ;
+    dcterms:identifier 33 ;
+    void:inDataset <https://id.erfgoed.net/datasets/thesauri/waardetypes> ;
+    skos:inScheme <https://id.erfgoed.net/thesauri/waardetypes> ;
+    skos:prefLabel "cultuurhistorische waarde"@nl-BE ;
+    skos:scopeNote "Cultuurhistorische waarden geven uiting aan de manier waarop de mens vroeger met het landschap omging. Het gaat dan vooral om de beschrijving van elementen en structuren die door mensen aangebracht en in stand gehouden werden in vroegere perioden en hun historische ontwikkeling. De referentiesituatie en –datum kunnen daarbij worden beschreven. In het huidige landschap wordt vooral gezocht naar de aanwezigheid van karakteristieken en getuigen van de vroegere referentiesituatie. Veranderingen en constantheid spelen daarbij een rol. (bron: interne handleiding Ankerplaatsen)"@nl-BE .
+
+<https://id.erfgoed.net/thesauri/waardetypes/34> a skos:Concept ;
+    dcterms:identifier 34 ;
+    void:inDataset <https://id.erfgoed.net/datasets/thesauri/waardetypes> ;
+    skos:inScheme <https://id.erfgoed.net/thesauri/waardetypes> ;
+    skos:prefLabel "functionele waarde"@nl-BE .
+
+<https://id.erfgoed.net/thesauri/waardetypes/35> a skos:Concept ;
+    dcterms:identifier 35 ;
+    void:inDataset <https://id.erfgoed.net/datasets/thesauri/waardetypes> ;
+    skos:inScheme <https://id.erfgoed.net/thesauri/waardetypes> ;
+    skos:prefLabel "visuele waarde"@nl-BE .
+
+<https://id.erfgoed.net/thesauri/waardetypes/36> a skos:Concept ;
+    dcterms:identifier 36 ;
+    void:inDataset <https://id.erfgoed.net/datasets/thesauri/waardetypes> ;
+    skos:inScheme <https://id.erfgoed.net/thesauri/waardetypes> ;
+    skos:prefLabel "natuurwetenschappelijke waarde"@nl-BE ;
+    skos:scopeNote "Onder de natuurwetenschappelijke waarde worden het bewaarde natuurlijke reliëf, de geologische opbouw en de typische begroeiing, fauna, flora begrepen."@nl-BE .
+
+<https://id.erfgoed.net/thesauri/waardetypes/38> a skos:Concept ;
+    dcterms:identifier 38 ;
+    dcterms:source [ a dcterms:BibliographicResource ;
+            dcterms:bibliographicCitation "Vlaamse overheid Ruimtelijke Ordening, Woonbeleid en Onroerend Erfgoed 17 JULI 2015. — Ministerieel besluit tot vaststelling van de inventarismethodologie voor de inventaris van archeologische zones, bl. 48924." ] ;
+    void:inDataset <https://id.erfgoed.net/datasets/thesauri/waardetypes> ;
+    skos:historyNote """23/03/2O16: SN toegevoegd bij afstemmen thesaurus met CGP.
+Versie 2015: De archeologische waarde is het gegeven dat een roerend of onroerend goed, als overblijfsel of ander spoor van menselijk bestaan en de menselijke bestaansomgeving in het verleden, door behoud of door bestudering bijdraagt tot de reconstructie van de bestaansgeschiedenis van de mensheid en haar relatie tot die omgeving. (Bron: Code Goede Praktijk)"""@nl-BE ;
+    skos:inScheme <https://id.erfgoed.net/thesauri/waardetypes> ;
+    skos:notation "OE-38" ;
+    skos:prefLabel "archeologische waarde"@nl-BE ;
+    skos:scopeNote "Een onroerend goed heeft archeologische waarde als het betekenisvol kan bijdragen tot de reconstructie van de bestaansgeschiedenis van de mensheid en haar relatie tot de omgeving door de daar aanwezige overblijfselen, voorwerpen of sporen van de mens en zijn omgeving te behouden of ze met archeologische en natuurwetenschappelijke methoden te onderzoeken."@nl-BE .
+
+<https://id.erfgoed.net/thesauri/waardetypes/39> a skos:Concept ;
+    dcterms:identifier 39 ;
+    dcterms:source [ a dcterms:BibliographicResource ;
+            dcterms:bibliographicCitation "Vlaamse overheid Ruimtelijke Ordening, Woonbeleid en Onroerend Erfgoed 17 JULI 2015. — Ministerieel besluit tot vaststelling van de inventarismethodologie voor de inventaris van bouwkundig erfgoed, bl. 48925." ] ;
+    void:inDataset <https://id.erfgoed.net/datasets/thesauri/waardetypes> ;
+    skos:inScheme <https://id.erfgoed.net/thesauri/waardetypes> ;
+    skos:note """Deze waarde kan worden gelijkgesteld aan de vroegere in-casu-waarde “architectuurhistorische waarde”. De discussie gaat over de interpretatie van de term ‘architecturaal’ als beperkt tot materiële zaken, objectgericht, bouwstijl (e.d.) versus ruimer met inbegrip van de immateriële elementen zoals wooncultuur, een historisch referentiekader (e.d.). En over het onderscheid tussen de ‘architecturale’ en de ‘culturele’ waarde. Waarbij de ‘culturele’ waarde eerder voor de duiding van grote tendensen/fenomenen (zoals de impact van WO) zou gebruikt worden. 
+De invalshoek op het te beschermen object zal bepalend zijn voor de waarden die men toekent en de opmaak van het dossier. 
+Consensus dat architecturale waarde meer de nadruk legt op het materiële, de (bouw)evolutie, typologie, de bouwstijl, oeuvre, materiaalgebruik."""@nl-BE ;
+    skos:prefLabel "architecturale waarde"@nl-BE ;
+    skos:scopeNote "Een onroerend goed heeft architecturale waarde als het getuigt van een fase of aspect van de (landschaps)architectuur of de bouwkunst in het verleden. Het kan gaan om typologie, stijl, oeuvre of materiaalgebruik."@nl-BE .
+
+<https://id.erfgoed.net/thesauri/waardetypes/40> a skos:Concept ;
+    dcterms:identifier 40 ;
+    dcterms:source [ a dcterms:BibliographicResource ;
+            dcterms:bibliographicCitation "Vlaamse overheid Ruimtelijke Ordening, Woonbeleid en Onroerend Erfgoed 17 JULI 2015. — Ministerieel besluit tot vaststelling van de inventarismethodologie voor de inventaris van bouwkundig erfgoed, bl. 48925." ] ;
+    void:inDataset <https://id.erfgoed.net/datasets/thesauri/waardetypes> ;
+    skos:historyNote """Versie 2015: een gebouw of ensemble heeft artistieke waarde wanneer het een originele creatie is die getuigt van het vakmanschap en de begaafdheid van de kunstenaar en waarvan de betekenis niet ligt in zijn praktische functie, maar besloten in de verschijningswijze zelf. Deze verschijningswijze gaat gepaard met de expressie van een emotie en de overdracht hiervan op de consument, waarvan een zekere ontvankelijkheid en geschooldheid wordt verwacht. (bron: document Claartje)
+Alternatieve SN (bron: handleiding inventariseren): bv. het oeuvre van een bepaalde architect (fig. 1); een 18de-eeuws hotel in verfijnde rococo; een standbeeld van de hand van een gerenommeerd kunstenaar. De artistieke waarde ligt ook in een
+verzorgde uitwerking van gevelornamentiek en interieurelementen of de betrokkenheid van bepaalde kunstenaars of ambachtslui."""@nl-BE ;
+    skos:inScheme <https://id.erfgoed.net/thesauri/waardetypes> ;
+    skos:note "De artistieke waarde omvat ook het vakmanschap; een bewuste handeling van de mens."@nl-BE ;
+    skos:prefLabel "artistieke waarde"@nl-BE ;
+    skos:scopeNote "Een onroerend goed heeft artistieke waarde als het getuigt van het kunstzinnige streven van de mens in het verleden."@nl-BE .
+
+<https://id.erfgoed.net/thesauri/waardetypes/41> a skos:Concept ;
+    dcterms:identifier 41 ;
+    dcterms:source [ a dcterms:BibliographicResource ;
+            dcterms:bibliographicCitation "Vlaamse overheid Ruimtelijke Ordening, Woonbeleid en Onroerend Erfgoed 17 JULI 2015. — Ministerieel besluit tot vaststelling van de inventarismethodologie voor de inventaris van bouwkundig erfgoed, bl. 48925." ] ;
+    void:inDataset <https://id.erfgoed.net/datasets/thesauri/waardetypes> ;
+    skos:inScheme <https://id.erfgoed.net/thesauri/waardetypes> ;
+    skos:prefLabel "culturele waarde"@nl-BE ;
+    skos:scopeNote "Een onroerend goed heeft culturele waarde als het getuigt van tijd- en regiogebonden menselijk gedrag."@nl-BE .
+
+<https://id.erfgoed.net/thesauri/waardetypes/42> a skos:Concept ;
+    dcterms:identifier 42 ;
+    dcterms:source [ a dcterms:BibliographicResource ;
+            dcterms:bibliographicCitation "Vlaamse overheid Ruimtelijke Ordening, Woonbeleid en Onroerend Erfgoed 17 JULI 2015. — Ministerieel besluit tot vaststelling van de inventarismethodologie voor de inventaris van bouwkundig erfgoed, bl. 48925." ] ;
+    void:inDataset <https://id.erfgoed.net/datasets/thesauri/waardetypes> ;
+    skos:historyNote "Versie 2015: De esthetische waarde heeft betrekking op het visuele aspect van het betreffend onroerend goed en gaat samen met kwaliteit en gebruikswaarde. Het visuele aspect bestaat uit diverse componenten. Zo speelt herkenbaarheid een belangrijke rol, dit wordt bepaald door mogelijkheid tot oriëntatie, identiteit en samenhang. Andere visuele aspecten zijn het beeldbepalende karakter en bepaalde elementen, de schaal, uitgestrektheid en uitzicht, etc. Ook de orde, zorg, netheid en gaafheid vergroten de esthetische waarde. Voor landschappen zal enige variatie in reliëf, landgebruik etc. de esthetische waarde tevens ten goede komen. (bron: interne handleiding Ankerplaatsen)"@nl-BE ;
+    skos:inScheme <https://id.erfgoed.net/thesauri/waardetypes> ;
+    skos:note "De zintuigelijke ervaring door de mens staat centraal bij de esthetische waarde. Het kan betrekking  hebben op bv. de esthetische ligging van een militaire begraafplaats in zijn omgeving; op bv. een mooi plein in een stad/gemeente dat organisch ontstaan is; bv een park dat in reisverslagen als ‘mooi park’ bejubeld wordt. Opmerking: zichtbare componenten spelen een belangrijke rol: combinaties kleur, vorm, harmonische verhoudingen, … (maar geur en stilte kunnen ook in geval van een landschap). Voor bouwkundig erfgoed is het moeilijker te definiëren en zal eerder de artistieke waarde gebruikt worden."@nl-BE ;
+    skos:prefLabel "esthetische waarde"@nl-BE ;
+    skos:scopeNote "Een onroerend goed heeft esthetische waarde als het de waarnemer zintuiglijke schoonheid laat ervaren."@nl-BE .
+
+<https://id.erfgoed.net/thesauri/waardetypes/43> a skos:Concept ;
+    dcterms:identifier 43 ;
+    dcterms:source [ a dcterms:BibliographicResource ;
+            dcterms:bibliographicCitation "Vlaamse overheid Ruimtelijke Ordening, Woonbeleid en Onroerend Erfgoed 17 JULI 2015. — Ministerieel besluit tot vaststelling van de inventarismethodologie voor de inventaris van bouwkundig erfgoed, bl. 48925." ] ;
+    void:inDataset <https://id.erfgoed.net/datasets/thesauri/waardetypes> ;
+    skos:historyNote """Versie 2015: Al dan niet met personen of instellingen verbonden historische reminiscenties of achtergronden die beschermd erfgoed kan bezitten. De historische waarde kan gevat worden in termen van politieke geschiedenis, architectuurgeschiedenis, cultuurhistorie, e.d. (bron: document Claartje)
+Alternatieve SN (handleiding inventariseren): bijvoorbeeld het belang van dit object binnen het ontstaan en de ontwikkeling van een regio, gemeente, wijk en straat. De historische waarde van een object kan ook ontleend zijn aan zijn militair-historische betekenis (bv. wereldoorlogerfgoed) of de link met een historisch belangrijke persoon."""@nl-BE ;
+    skos:inScheme <https://id.erfgoed.net/thesauri/waardetypes> ;
+    skos:prefLabel "historische waarde"@nl-BE ;
+    skos:scopeNote "Een onroerend goed heeft historische waarde als het getuigt van een (maatschappelijke) ontwikkeling, gebeurtenis, figuur, instelling of landgebruik uit het verleden van de mens."@nl-BE .
+
+<https://id.erfgoed.net/thesauri/waardetypes/44> a skos:Concept ;
+    dcterms:identifier 44 ;
+    dcterms:source [ a dcterms:BibliographicResource ;
+            dcterms:bibliographicCitation "Vlaamse overheid Ruimtelijke Ordening, Woonbeleid en Onroerend Erfgoed 17 JULI 2015. — Ministerieel besluit tot vaststelling van de inventarismethodologie voor de inventaris van bouwkundig erfgoed, bl. 48925." ] ;
+    void:inDataset <https://id.erfgoed.net/datasets/thesauri/waardetypes> ;
+    skos:historyNote "Versie 2015: de mate waarin een bescherming kan verantwoord worden omwille van zijn belang in de geschiedenis van de handel en industrie, de sociale geschiedenis van de geschiedenis van de techniek. bv. kasseiwegen, molens, steenovens, hopasten en fabrieken als getuigen van een ambachtelijk of industrieel verleden.(bron: document Claartje &amp; handleiding inventariseren)"@nl-BE ;
+    skos:inScheme <https://id.erfgoed.net/thesauri/waardetypes> ;
+    skos:note "De afleesbaarheid van het productieproces is erg belangrijk. Liefst inrichting bewaard. Volledig “leeggehaald” industrieel gebouw krijgt beter architecturale waarde."@nl-BE ;
+    skos:prefLabel "industrieel-archeologische waarde"@nl-BE ;
+    skos:scopeNote "Een onroerend goed heeft industrieel-archeologische waarde als het getuigt van een ambachtelijk of industrieel verleden."@nl-BE .
+
+<https://id.erfgoed.net/thesauri/waardetypes/45> a skos:Concept ;
+    dcterms:identifier 45 ;
+    dcterms:source [ a dcterms:BibliographicResource ;
+            dcterms:bibliographicCitation "Vlaamse overheid Ruimtelijke Ordening, Woonbeleid en Onroerend Erfgoed 17 JULI 2015. — Ministerieel besluit tot vaststelling van de inventarismethodologie voor de inventaris van bouwkundig erfgoed, bl. 48925." ] ;
+    void:inDataset <https://id.erfgoed.net/datasets/thesauri/waardetypes> ;
+    skos:inScheme <https://id.erfgoed.net/thesauri/waardetypes> ;
+    skos:note """Vroeger werd dit onder de wetenschappelijke of industrieel-archeologische waarde geplaatst. Bouwtechniek primeert bij deze waarde.
+Voorbeelden: Gebruik van gewapend beton; Specifieke vorm van overspanning bij een brug; Atoomcentrum Mol; Voorbeeld van een bepaalde vakwerktechniek; Sluizen en wateringen als voorbeeld van ontwikkeling in landbouw en waterbeheersing..."""@nl-BE ;
+    skos:prefLabel "technische waarde"@nl-BE ;
+    skos:scopeNote "Een onroerend goed heeft technische waarde als het de ontwikkeling van de (cultuur)techniek in het verleden illustreert. Het gaat om technische toepassingen als illustratie van zowel traditionele als innovatieve technieken en materialen."@nl-BE .
+
+<https://id.erfgoed.net/thesauri/waardetypes/46> a skos:Concept ;
+    dcterms:identifier 46 ;
+    dcterms:source [ a dcterms:BibliographicResource ;
+            dcterms:bibliographicCitation "Vlaamse overheid Ruimtelijke Ordening, Woonbeleid en Onroerend Erfgoed 17 JULI 2015. — Ministerieel besluit tot vaststelling van de inventarismethodologie voor de inventaris van bouwkundig erfgoed, bl. 48925." ] ;
+    void:inDataset <https://id.erfgoed.net/datasets/thesauri/waardetypes> ;
+    skos:historyNote "Versie 2015: De ruimtelijk-structurerende waarde heeft betrekking op de manier waarop het onroerend erfgoed ruimtelijk gestructureerd wordt door  bepaalde elementen. Het kunnen landschapskenmerken of bouwkundige elementen zijn die door hun aanwezigheid een invloed hebben of hadden op de ruimtelijke configuratie en/of organisatie van het (omliggende) landschap (vb. beken, valleien, abdijen, wegen, etc.). Het landschapskenmerk/bouwkundig element kan visueel dominant aanwezig zijn in het landschap en een bakenfunctie hebben (vb. bossen, kerken, kasteel, etc.). Tenslotte kan het element, of de cluster  van elementen, kenmerkend zijn voor de streek of het landschap (vb. vakwerkbouw, laagstamboomgaarden Sint-Truiden-Borgloon, etc.). (bron: interne handleiding Ankerplaatsen)"@nl-BE ;
+    skos:inScheme <https://id.erfgoed.net/thesauri/waardetypes> ;
+    skos:note """Het onderscheid tussen de ruimtelijk-structurerende (RS) en de stedenbouwkundige (S) waarde is niet altijd duidelijk. De RS-waarde is globaler en actueel nog zichtbaar. Vaak zal het om één object gaan, al is dit erg groot &lt;&gt; stedenbouwkundige waarde: gaat vaker over ensemble.
+Voorbeelden: Een kanaal door een stad; Iets wat visueel en ruimtelijk erg dominant is: een groenas, dreef, spoorweg; een dries in een dorp; een kerk als baken in het landschap/omgeving..."""@nl-BE ;
+    skos:prefLabel "ruimtelijk-structurerende waarde"@nl-BE ;
+    skos:scopeNote "Een onroerend goed heeft ruimtelijk-structurerende waarde als het de ruimte ordent, afbakent, structureert of de blik leidt."@nl-BE .
+
+<https://id.erfgoed.net/thesauri/waardetypes/47> a skos:Concept ;
+    dcterms:identifier 47 ;
+    dcterms:source [ a dcterms:BibliographicResource ;
+            dcterms:bibliographicCitation "Vlaamse overheid Ruimtelijke Ordening, Woonbeleid en Onroerend Erfgoed 17 JULI 2015. — Ministerieel besluit tot vaststelling van de inventarismethodologie voor de inventaris van bouwkundig erfgoed, bl. 48925." ] ;
+    void:inDataset <https://id.erfgoed.net/datasets/thesauri/waardetypes> ;
+    skos:topConceptOf <https://id.erfgoed.net/thesauri/waardetypes> ;
+    skos:note """De continuïteit van de sociale waarde is belangrijk. 
+Voorbeelden: Iets wat nog steeds fungeert als een ontmoetingsplek: gemeenschapscentra, dorpspleinen waar bevolking nog regelmatig samenkomt; herdenkingsmonument waarbij nog regelmatig wordt samengekomen (Menenpoort, Ieper, maar kan ook op lokaal vlak); bedevaartsoorden die nog worden bezocht..."""@nl-BE ;
+    skos:prefLabel "sociale waarde"@nl-BE ;
+    skos:scopeNote "Een onroerend goed heeft sociale waarde als het in de hedendaagse gemeenschap nog een actief, overgeleverd sociaal gebruik heeft of gemeenschapsvormend is blijven werken."@nl-BE .
+
+<https://id.erfgoed.net/thesauri/waardetypes/48> a skos:Concept ;
+    dcterms:identifier 48 ;
+    dcterms:source [ a dcterms:BibliographicResource ;
+            dcterms:bibliographicCitation "Vlaamse overheid Ruimtelijke Ordening, Woonbeleid en Onroerend Erfgoed 17 JULI 2015. — Ministerieel besluit tot vaststelling van de inventarismethodologie voor de inventaris van bouwkundig erfgoed, bl. 48925." ] ;
+    void:inDataset <https://id.erfgoed.net/datasets/thesauri/waardetypes> ;
+    skos:topConceptOf <https://id.erfgoed.net/thesauri/waardetypes> ;
+    skos:note """De nadruk bij de stedenbouwkundige waarde ligt meer op het verleden, een historisch kader. Bv. woning Dhanis als element in de ontwikkeling van de leien in de 19de eeuw. De waarde kan betrekking hebben op zowel een organisch gegroeide (bv. marktplein) als een planmatige (bv. sociale woonwijk) aanleg. Vaak speelt de ensemblewaarde een rol; de relatie tussen meerdere elementen.
+Er wordt voorgesteld de RS-waarde te gebruiken voor een iets beperktere omgeving en de S-waarde voor een grotere omgeving waaronder verschillende RS-elementen kunnen worden ondergebracht. 
+Voorbeelden: kerk, station samen met planmatig aangelegd stratenpatroon; Een kasteel dat focuspunt is van een ruimer assenpatroon in de omgevende bossen; Schikking gebouwen rond marktplein; Patroon sociale woonwijk…"""@nl-BE ;
+    skos:prefLabel "stedenbouwkundige waarde"@nl-BE ;
+    skos:scopeNote "Een onroerend goed heeft stedenbouwkundige waarde als het een rol speelt in de (planmatige) inrichting van de bebouwde ruimte in het verleden. Die inrichting omvat ook de wisselwerking tussen open en bebouwde ruimte en de samenhang tussen de verschillende schaalniveaus."@nl-BE .
+
+<https://id.erfgoed.net/thesauri/waardetypes/49> a skos:Concept ;
+    dcterms:identifier 49 ;
+    dcterms:source [ a dcterms:BibliographicResource ;
+            dcterms:bibliographicCitation "Vlaamse overheid Ruimtelijke Ordening, Woonbeleid en Onroerend Erfgoed 17 JULI 2015. — Ministerieel besluit tot vaststelling van de inventarismethodologie voor de inventaris van bouwkundig erfgoed, bl. 48925." ] ;
+    void:inDataset <https://id.erfgoed.net/datasets/thesauri/waardetypes> ;
+    skos:topConceptOf <https://id.erfgoed.net/thesauri/waardetypes> ;
+    skos:prefLabel "volkskundige waarde"@nl-BE ;
+    skos:scopeNote "Een onroerend goed heeft volkskundige waarde als het getuigt van gebruiken en gewoonten, voorstellingen en tradities van een specifieke bevolkingsgroep of gemeenschap in het verleden."@nl-BE .
+
+<https://id.erfgoed.net/thesauri/waardetypes/50> a skos:Concept ;
+    dcterms:identifier 50 ;
+    dcterms:source [ a dcterms:BibliographicResource ;
+            dcterms:bibliographicCitation "Vlaamse overheid Ruimtelijke Ordening, Woonbeleid en Onroerend Erfgoed 17 JULI 2015. — Ministerieel besluit tot vaststelling van de inventarismethodologie voor de inventaris van bouwkundig erfgoed, bl. 48925." ] ;
+    void:inDataset <https://id.erfgoed.net/datasets/thesauri/waardetypes> ;
+    skos:historyNote """Versie 2015: Onder wetenschappelijke waarde verstaat men verzamelingen instrumenten, machines of toestellen in situ bv. gebouwen en inrichtingen die de ontwikkeling van een bepaald productieproces illustreren; gebouwen of
+bouwwerken die de ontwikkeling van bepaalde technieken, het gebruik van nieuwe materialen, etc., illustreren (bv. vroeg gebruik van gewapend beton, specifieke vorm van overspanning bij een brug). (bron: document Claartje &amp; handleiding inventariseren)"""@nl-BE ;
+    skos:topConceptOf <https://id.erfgoed.net/thesauri/waardetypes> ;
+    skos:note """De wetenschappelijke waarde moet bewust, fundamenteel en zeker zijn.
+De formulering “Potentie voor kennisontwikkeling en winst” is ingegeven vanuit archeologie, maar kan ook voor bouwkundig erfgoed relevant zijn. Bv een kerkgebouw opgebouwd uit verschillende soorten natuursteen. Hierin schuilt de potentie van kennis die  uit de studie van deze materialen kan gehaald worden.  
+De formulering “Iets dat een bijzondere bijdrage geleverd heeft of een typevoorbeeld is” is ingegeven vanuit landschappen. Vb. dendrologisch waardevolle bomen.
+Voorbeelden: Archeologische site; site met aardkundige waarden (paleomeanders, paraboolduinen, bodemprofiel dat geologische gelaagdheid aan het licht brengt); Wetenschappelijke collectie; Referentiecollectie; Geodetisch punt (belangrijk voor ontwikkeling cartografie); gebouw met bijzondere rijke collectie steensoorten; Collectie genetisch (plant)materiaal; een universiteit met een klein museum bewust aangelegd met een referentiecollectie voor studenten of docenten."""@nl-BE ;
+    skos:prefLabel "wetenschappelijke waarde"@nl-BE ;
+    skos:scopeNote "Een onroerend goed heeft wetenschappelijke waarde als het potentie heeft voor kennisontwikkeling en kenniswinst over een bepaald thema, periode of fenomeen, als het een bijzondere bijdrage geleverd heeft op dat vlak of als het een typevoorbeeld is."@nl-BE .
+
+<https://id.erfgoed.net/thesauri/waardetypes> a skos:ConceptScheme ;
+    dcterms:identifier "WAARDETYPES" ;
+    void:inDataset <https://id.erfgoed.net/datasets/thesauri/waardetypes> ;
+    skos:hasTopConcept <https://id.erfgoed.net/thesauri/waardetypes/31>,
+        <https://id.erfgoed.net/thesauri/waardetypes/32>,
+        <https://id.erfgoed.net/thesauri/waardetypes/33>,
+        <https://id.erfgoed.net/thesauri/waardetypes/34>,
+        <https://id.erfgoed.net/thesauri/waardetypes/35>,
+        <https://id.erfgoed.net/thesauri/waardetypes/36>,
+        <https://id.erfgoed.net/thesauri/waardetypes/38>,
+        <https://id.erfgoed.net/thesauri/waardetypes/39>,
+        <https://id.erfgoed.net/thesauri/waardetypes/40>,
+        <https://id.erfgoed.net/thesauri/waardetypes/41>,
+        <https://id.erfgoed.net/thesauri/waardetypes/42>,
+        <https://id.erfgoed.net/thesauri/waardetypes/43>,
+        <https://id.erfgoed.net/thesauri/waardetypes/44>,
+        <https://id.erfgoed.net/thesauri/waardetypes/45>,
+        <https://id.erfgoed.net/thesauri/waardetypes/46>,
+        <https://id.erfgoed.net/thesauri/waardetypes/47>,
+        <https://id.erfgoed.net/thesauri/waardetypes/48>,
+        <https://id.erfgoed.net/thesauri/waardetypes/49>,
+        <https://id.erfgoed.net/thesauri/waardetypes/50> ;
+    skos:prefLabel "Value types"@en,
+        "Waarde types"@nl .
+

--- a/tests/rdf/conftest.py
+++ b/tests/rdf/conftest.py
@@ -1,0 +1,47 @@
+import json
+import os
+
+import pytest
+from rdflib import Graph
+
+from skosprovider.providers import DictionaryProvider
+from skosprovider.rdf.providers import RDFProvider
+from skosprovider.skos import ConceptScheme
+from skosprovider.skos import Label
+from skosprovider.skos import Note
+from skosprovider.uri import UriPatternGenerator
+
+DATA_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), 'data')
+
+
+@pytest.fixture(scope='module')
+def products_provider():
+    products_graph = Graph()
+    products_graph.parse(os.path.join(DATA_DIR, 'simple_turtle_products'), format='turtle')
+    return RDFProvider({'id': 'PRODUCTS'}, products_graph)
+
+
+@pytest.fixture(scope='module')
+def trees_provider():
+    trees_graph = Graph()
+    trees_graph.parse(os.path.join(DATA_DIR, 'trees.xml'), format='application/rdf+xml')
+    return RDFProvider({'id': 'TREES'}, trees_graph)
+
+
+@pytest.fixture(scope='module')
+def materials_provider():
+    materials_data = json.load(open(os.path.join(DATA_DIR, 'materiaal.txt')))['materiaal']
+    return DictionaryProvider(
+        {'id': 'Materials'},
+        materials_data,
+        uri_generator=UriPatternGenerator('https://id.erfgoed.net/thesauri/materialen/%s'),
+        conceptscheme=ConceptScheme(
+            uri='https://id.erfgoed.net/thesauri/materialen',
+            labels=[Label(type='prefLabel', language='nl', label='Materialen')],
+            notes=[Note(
+                type='scopeNote',
+                language='nl',
+                note='Materialen zijn grondstoffen of halfafgewerkte producten die vaak een rol spelen bij onroerend erfgoed.'
+            )]
+        )
+    )

--- a/tests/rdf/test_providers.py
+++ b/tests/rdf/test_providers.py
@@ -1,0 +1,449 @@
+import os
+
+import pytest
+import rdflib
+from rdflib import Graph
+from rdflib import Literal
+from rdflib import URIRef
+from rdflib.namespace import SKOS
+from skosprovider.skos import Collection
+from skosprovider.skos import ConceptScheme
+from skosprovider.skos import Note
+from skosprovider.utils import dict_dumper
+
+from skosprovider.rdf.providers import RDFProvider
+
+DATA_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), 'data')
+
+
+class TestRDFProviderProducts:
+
+    def test_get_vocabulary_id(self, products_provider):
+        assert 'PRODUCTS' == products_provider.get_vocabulary_id()
+
+    def test_conceptscheme(self, products_provider):
+        cs = products_provider.concept_scheme
+
+        assert cs.uri == 'http://www.products.com/Scheme'
+        assert cs.label('en') is not None
+        assert len(cs.languages) == 3
+
+    def test_get_concept_by_id(self, products_provider):
+        u_jewellery = "http://www.products.com/Jewellery"
+        u_perfume = "http://www.products.com/Perfume"
+        from skosprovider.skos import Concept
+
+        con = products_provider.get_by_id(u_jewellery)
+        assert isinstance(con, Concept)
+        assert u_jewellery == con.id
+        assert u_jewellery == con.uri
+        assert u_perfume in con.related
+
+    def test_get_unexisting_by_id(self, products_provider):
+        con = products_provider.get_by_id(404)
+        assert not con
+
+    def test_createLabel(self, products_provider):
+        with pytest.raises(ValueError):
+            products_provider._create_label("literal", "nonexistinglabeltype")
+
+    def test_createNote(self, products_provider):
+        with pytest.raises(ValueError):
+            products_provider._create_note("literal", "nonexistingnotetype")
+
+    def test_get_concept_by_uri_equals_id(self, products_provider):
+        u_product = "http://www.products.com/Product"
+        cona = products_provider.get_by_id(u_product)
+        conb = products_provider.get_by_uri(u_product)
+        assert cona == conb
+
+    def test_get_unexisting_by_uri(self, products_provider):
+        con = products_provider.get_by_uri('http://www.products.com/Thingy')
+        assert not con
+
+    def test_concept_has_correct_note(self, products_provider):
+        u_jewellery = "http://www.products.com/Jewellery"
+        con = products_provider.get_by_id(u_jewellery)
+        assert len(con.notes) == 2
+        assert isinstance(con.notes[0], Note)
+
+    def test_get_collection_by_id(self, products_provider):
+        u_stuff = "http://www.products.com/Stuff"
+        u_product = "http://www.products.com/Product"
+        col = products_provider.get_by_id(u_stuff)
+        assert isinstance(col, Collection)
+        assert u_stuff == col.id
+        assert u_product in col.members
+        for m in col.members:
+            m = products_provider.get_by_id(m)
+            assert col.id in m.member_of
+
+    def test_get_collection_by_uri_equals_id(self, products_provider):
+        u_stuff = "http://www.products.com/Stuff"
+        cola = products_provider.get_by_id(u_stuff)
+        colb = products_provider.get_by_uri(u_stuff)
+        assert cola.id == colb.id
+        assert cola.uri == colb.uri
+
+    def test_get_all(self, products_provider):
+        all = products_provider.get_all()
+        assert len(all) == 4
+
+    def test_get_top_concepts(self, products_provider):
+        all = products_provider.get_top_concepts()
+        assert len(all) == 1
+
+    def test_get_top_display(self, products_provider):
+        all = products_provider.get_top_display()
+        assert len(all) == 1
+
+    def test_get_children_display_unexisting(self, products_provider):
+        assert not products_provider.get_children_display(700)
+
+    def test_get_children_display_collection(self, products_provider):
+        u_stuff = "http://www.products.com/Stuff"
+        children = products_provider.get_children_display(u_stuff)
+        assert len(children) == 3
+
+    def test_get_children_display_concept(self, products_provider):
+        u_product = "http://www.products.com/Product"
+        children = products_provider.get_children_display(u_product)
+        assert len(children) == 2
+
+    def test_find_all(self, products_provider):
+        all = products_provider.find({})
+        assert len(all) == 4
+
+    def test_find_type_all(self, products_provider):
+        all = products_provider.find({'type': 'all'})
+        assert len(all) == 4
+
+    def test_find_type_concept(self, products_provider):
+        all = products_provider.find({'type': 'concept'})
+        assert len(all) == 3
+
+    def test_find_type_collection(self, products_provider):
+        all = products_provider.find({'type': 'collection'})
+        assert len(all) == 1
+
+    def test_find_label_perfume(self, products_provider):
+        all = products_provider.find({'label': 'Perfume'})
+        assert len(all) == 1
+
+    def test_find_label_perfume_type_concept(self, products_provider):
+        all = products_provider.find({'label': 'Perfume', 'type': 'concept'})
+        assert len(all) == 1
+
+    def test_find_collection_unexisting(self, products_provider):
+        with pytest.raises(ValueError):
+            products_provider.find({'collection': {'id': 404}})
+
+    def test_find_collection_stuff_no_depth(self, products_provider):
+        u_stuff = "http://www.products.com/Stuff"
+        all = products_provider.find({'collection': {'id': u_stuff}})
+        assert len(all) == 3
+
+    def test_expand_concept(self, products_provider):
+        u_product = "http://www.products.com/Product"
+        u_perfume = "http://www.products.com/Perfume"
+        ids = products_provider.expand(u_product)
+        assert u_perfume in ids
+
+    def test_expand_collection(self, products_provider):
+        u_stuff = "http://www.products.com/Stuff"
+        u_perfume = "http://www.products.com/Perfume"
+        ids = products_provider.expand(u_stuff)
+        assert u_perfume in ids
+
+    def test_expand_unexisting(self, products_provider):
+        ids = products_provider.expand(404)
+        assert not ids
+
+    def test_no_literal(self, products_provider):
+        assert products_provider._get_language_from_literal("test") is None
+
+    def test_concept_extra_data(self, products_provider):
+        u_product = "http://www.products.com/Product"
+        con = products_provider.get_by_id(u_product)
+        assert isinstance(con.extra_data, rdflib.Graph)
+        assert (URIRef(u_product), SKOS.notation, Literal("PROD-001")) in con.extra_data
+        assert (
+            URIRef(u_product),
+            URIRef("http://www.products.com/properties/internalCode"),
+            Literal("P1"),
+        ) in con.extra_data
+
+    def test_concept_without_extra_data(self, products_provider):
+        u_perfume = "http://www.products.com/Perfume"
+        con = products_provider.get_by_id(u_perfume)
+        assert con.extra_data is None
+
+
+class TestMultipleConceptschemes:
+
+    def test_pick_one_conceptscheme(self):
+        wb_graph = Graph()
+        wb_graph.parse(os.path.join(DATA_DIR, 'waarde_en_besluit_types.ttl'), format='turtle')
+        wb_provider = RDFProvider(
+            {'id': 'WAARDETYPES'},
+            wb_graph,
+            concept_scheme_uri='https://id.erfgoed.net/thesauri/waardetypes'
+        )
+        assert 'https://id.erfgoed.net/thesauri/waardetypes' == wb_provider.concept_scheme.uri
+        assert len(wb_provider.get_all()) == 21
+
+    def test_set_a_conceptscheme_manually(self):
+        wb_graph = Graph()
+        wb_graph.parse(os.path.join(DATA_DIR, 'waarde_en_besluit_types.ttl'), format='turtle')
+        wb_provider = RDFProvider(
+            {'id': 'WAARDETYPES'},
+            wb_graph,
+            concept_scheme=ConceptScheme('https://id.erfgoed.net/thesauri/besluittypes')
+        )
+        assert 'https://id.erfgoed.net/thesauri/besluittypes' == wb_provider.concept_scheme.uri
+        assert len(wb_provider.get_all()) == 24
+
+    def test_pick_wrong_conceptscheme(self):
+        wb_graph = Graph()
+        wb_graph.parse(os.path.join(DATA_DIR, 'waarde_en_besluit_types.ttl'), format='turtle')
+        with pytest.raises(RuntimeError) as exc:
+            RDFProvider(
+                {'id': 'WAARTYPES'},
+                wb_graph,
+                concept_scheme_uri='https://id.erfgoed.net/thesauri/waartypes'
+            )
+        assert 'https://id.erfgoed.net/thesauri/waardetypes' in str(exc.value)
+        assert 'https://id.erfgoed.net/thesauri/besluittypes' in str(exc.value)
+
+    def test_too_many_conceptscheme(self):
+        toepassingen_graph = Graph()
+        toepassingen_graph.parse(os.path.join(DATA_DIR, 'schemes.xml'), format='application/rdf+xml')
+        with pytest.raises(RuntimeError) as exc:
+            RDFProvider({'id': 'TOEPASSINGEN'}, toepassingen_graph)
+        assert 'https://id.erfgoed.net/toepassingen' in str(exc.value)
+        assert 'https://id.erfgoed.net/applicaties' in str(exc.value)
+
+    def test_concept_extra_data(self):
+        wb_graph = Graph()
+        wb_graph.parse(os.path.join(DATA_DIR, 'waarde_en_besluit_types.ttl'), format='turtle')
+        wb_provider = RDFProvider(
+            {'id': 'WAARDETYPES'},
+            wb_graph,
+            concept_scheme_uri='https://id.erfgoed.net/thesauri/waardetypes'
+        )
+        u_arch = 'https://id.erfgoed.net/thesauri/waardetypes/38'
+        arch = wb_provider.get_by_uri(u_arch)
+        assert isinstance(arch.extra_data, rdflib.Graph)
+        assert (URIRef(u_arch), SKOS.notation, Literal("OE-38")) in arch.extra_data
+
+    def test_concept_without_extra_data(self):
+        wb_graph = Graph()
+        wb_graph.parse(os.path.join(DATA_DIR, 'waarde_en_besluit_types.ttl'), format='turtle')
+        wb_provider = RDFProvider(
+            {'id': 'WAARDETYPES'},
+            wb_graph,
+            concept_scheme_uri='https://id.erfgoed.net/thesauri/waardetypes'
+        )
+        u_arch = 'https://id.erfgoed.net/thesauri/waardetypes/39'
+        arch = wb_provider.get_by_uri(u_arch)
+        assert arch.extra_data is None
+
+
+class TestRDFProviderExtraData:
+
+    def _build_graph(self):
+        from rdflib.namespace import DCTERMS, RDF, SKOS
+        from rdflib import Literal, URIRef, Graph
+
+        g = Graph()
+        CS = URIRef("http://id.test.org")
+        CONCEPT = URIRef("http://id.test.org/1")
+        COLLECTION = URIRef("http://id.test.org/col")
+        CUSTOM = URIRef("http://example.org/custom#")
+
+        g.add((CS, RDF.type, SKOS.ConceptScheme))
+        g.add((CS, DCTERMS.identifier, Literal("TEST")))
+        g.add((CS, SKOS.prefLabel, Literal("Test", lang="en")))
+        g.add((CS, URIRef(CUSTOM + "schemeVersion"), Literal("2")))
+
+        g.add((CONCEPT, RDF.type, SKOS.Concept))
+        g.add((CONCEPT, SKOS.inScheme, CS))
+        g.add((CONCEPT, DCTERMS.identifier, Literal("1")))
+        g.add((CONCEPT, SKOS.prefLabel, Literal("Concept One", lang="en")))
+        g.add((CONCEPT, SKOS.notation, Literal("C-001")))
+
+        g.add((COLLECTION, RDF.type, SKOS.Collection))
+        g.add((COLLECTION, SKOS.inScheme, CS))
+        g.add((COLLECTION, DCTERMS.identifier, Literal("col")))
+        g.add((COLLECTION, SKOS.prefLabel, Literal("Collection", lang="en")))
+        g.add((COLLECTION, SKOS.member, CONCEPT))
+        g.add((COLLECTION, URIRef(CUSTOM + "collectionCode"), Literal("COL-001")))
+
+        return g
+
+    def test_concept_extra_data_graph(self):
+        provider = RDFProvider({"id": "TEST"}, self._build_graph())
+        concept = provider.get_by_uri("http://id.test.org/1")
+        assert isinstance(concept.extra_data, rdflib.Graph)
+        assert (
+            URIRef("http://id.test.org/1"),
+            SKOS.notation,
+            Literal("C-001"),
+        ) in concept.extra_data
+
+    def test_collection_extra_data_graph(self):
+        provider = RDFProvider({"id": "TEST"}, self._build_graph())
+        col = provider.get_by_uri("http://id.test.org/col")
+        assert isinstance(col.extra_data, rdflib.Graph)
+        assert (
+            URIRef("http://id.test.org/col"),
+            URIRef("http://example.org/custom#collectionCode"),
+            Literal("COL-001"),
+        ) in col.extra_data
+
+    def test_conceptscheme_extra_data_graph(self):
+        provider = RDFProvider({"id": "TEST"}, self._build_graph())
+        cs = provider.concept_scheme
+        assert isinstance(cs.extra_data, rdflib.Graph)
+        assert (
+            URIRef("http://id.test.org"),
+            URIRef("http://example.org/custom#schemeVersion"),
+            Literal("2"),
+        ) in cs.extra_data
+
+    def test_known_predicates_not_in_extra_data(self):
+        provider = RDFProvider({"id": "TEST"}, self._build_graph())
+        concept = provider.get_by_uri("http://id.test.org/1")
+        assert concept.extra_data is not None
+        assert (URIRef("http://id.test.org/1"), SKOS.prefLabel, None) not in [
+            (s, p, o) for s, p, o in concept.extra_data
+        ]
+
+    def test_no_extra_predicates_returns_none(self):
+        from rdflib.namespace import DCTERMS, RDF, SKOS
+        from rdflib import Literal, URIRef, Graph
+
+        g = Graph()
+        CS = URIRef("http://id.test.org")
+        CONCEPT = URIRef("http://id.test.org/1")
+        g.add((CS, RDF.type, SKOS.ConceptScheme))
+        g.add((CS, DCTERMS.identifier, Literal("TEST")))
+        g.add((CONCEPT, RDF.type, SKOS.Concept))
+        g.add((CONCEPT, SKOS.inScheme, CS))
+        g.add((CONCEPT, SKOS.prefLabel, Literal("Plain", lang="en")))
+
+        provider = RDFProvider({"id": "TEST"}, g)
+        concept = provider.get_by_uri("http://id.test.org/1")
+        assert concept.extra_data is None
+
+    def test_round_trip_extra_data_preserved(self):
+        from skosprovider.rdf import utils as rdf_utils
+
+        graph = self._build_graph()
+        provider = RDFProvider({"id": "TEST"}, graph)
+
+        def reinjector(out_graph, subject, obj):
+            if isinstance(obj.extra_data, rdflib.Graph):
+                for s, p, o in obj.extra_data.triples((subject, None, None)):
+                    out_graph.add((s, p, o))
+
+        dumped = rdf_utils.rdf_dumper(provider, extra_data_serializer=reinjector)
+        assert (
+            URIRef("http://id.test.org/1"),
+            SKOS.notation,
+            Literal("C-001"),
+        ) in dumped
+
+
+class TestTreeProvider:
+
+    def test_parse_without_conceptscheme_generates_default_uri(self, trees_provider):
+        assert 'urn:x-skosprovider:trees' == trees_provider.concept_scheme.uri
+
+    def test_parse_identifier(self, trees_provider):
+        larch = trees_provider.get_by_id('1')
+        assert larch.id == '1'
+
+        chestnut = trees_provider.get_by_id('2')
+        assert chestnut.id == '2'
+
+        species = trees_provider.get_by_id(3)
+        assert species.id == '3'
+
+        assert not trees_provider.get_by_id('http://id.trees.org/1')
+        assert not trees_provider.get_by_id('http://id.trees.org/2')
+        assert not trees_provider.get_by_id('http://id.trees.org/3')
+
+    def test_rdf_provider_list(self, trees_provider):
+        dump = dict_dumper(trees_provider)
+
+        assert len(dump) == 3
+        chestnut = [item for item in dump if item['uri'] == 'http://id.trees.org/2'][0]
+        assert chestnut['broader'] == []
+        assert chestnut['id'] == '2'
+        assert chestnut['member_of'] == ['3']
+        assert chestnut['narrower'] == []
+        label_en = [label for label in chestnut['labels'] if label['language'] == 'en'][0]
+        assert label_en == {'label': 'The Chestnut', 'language': 'en', 'type': 'prefLabel'}
+        label_nl = [label for label in chestnut['labels'] if label['language'] == 'nl'][0]
+        assert label_nl == {'label': 'De Paardekastanje', 'language': 'nl', 'type': 'altLabel'}
+        label_fr = [label for label in chestnut['labels'] if label['language'] == 'fr'][0]
+        assert type(label_fr['label']) == str
+        assert label_fr == {'label': 'la châtaigne', 'language': 'fr', 'type': 'altLabel'}
+        assert {
+            'language': 'en',
+            'note': '<p>A different type of tree.</p>',
+            'type': 'definition',
+            'markup': 'HTML'
+        } in chestnut['notes']
+        assert {
+            'language': 'und',
+            'note': 'Een ander soort boom.',
+            'type': 'definition',
+            'markup': 'HTML'
+        } in chestnut['notes']
+        assert {
+            'markup': 'HTML',
+            'citation': '<strong>Monthy Python.</strong> Episode Three: How to recognise different types of trees from quite a long way away.'
+        } in chestnut['sources']
+        larch = [item for item in dump if item['uri'] == 'http://id.trees.org/1'][0]
+        assert {
+            'citation': 'Monthy Python. Episode Three: How to recognise different types of trees from quite a long way away.',
+            'markup': None
+        } in larch['sources']
+        assert {
+            'language': 'en',
+            'note': 'A type of tree.',
+            'type': 'definition',
+            'markup': None
+        } in larch['notes']
+        assert {
+            'language': 'nl',
+            'note': '<p>Een soort boom.</p>',
+            'type': 'definition',
+            'markup': 'HTML'
+        } in larch['notes']
+
+    def test_find_matches_kastanjes(self, trees_provider):
+        kastanjes = trees_provider.find({
+            'matches': {'uri': 'https://id.erfgoed.net/thesauri/soorten/85'}
+        })
+        assert len(kastanjes) == 1
+
+    def test_find_matches_no_related_larches(self, trees_provider):
+        no_related_larches = trees_provider.find({
+            'matches': {
+                'uri': 'https://id.erfgoed.net/thesauri/soorten/666',
+                'type': 'related'
+            }
+        })
+        assert len(no_related_larches) == 0
+
+    def test_find_matches_close_larches(self, trees_provider):
+        close_larches = trees_provider.find({
+            'matches': {
+                'uri': 'https://id.erfgoed.net/thesauri/soorten/666',
+                'type': 'close'
+            }
+        })
+        assert len(close_larches) == 1

--- a/tests/rdf/test_utils.py
+++ b/tests/rdf/test_utils.py
@@ -1,0 +1,371 @@
+import logging
+
+import pytest
+from rdflib import Graph
+from rdflib import Namespace
+from rdflib.namespace import DC
+from rdflib.namespace import DCTERMS
+from rdflib.namespace import RDF
+from rdflib.namespace import SKOS
+from rdflib.term import Literal
+from rdflib.term import URIRef
+
+from skosprovider.providers import DictionaryProvider
+from skosprovider.rdf.providers import RDFProvider
+from skosprovider.rdf import utils
+from skosprovider.skos import ConceptScheme
+from skosprovider.skos import Label
+from skosprovider.skos import Note
+
+SKOS_THES = Namespace('http://purl.org/iso25964/skos-thes#')
+
+log = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope='module')
+def tree_provider():
+    larch = {
+        'id': '1',
+        'uri': 'http://id.trees.org/1',
+        'type': 'concept',
+        'labels': [
+            {'type': 'prefLabel', 'language': 'en', 'label': 'The Larch'},
+            {'type': 'prefLabel', 'language': 'nl', 'label': 'De Lariks'}
+        ],
+        'notes': [
+            {'type': 'definition', 'language': 'en', 'note': 'A type of tree.'},
+            {'type': 'definition', 'language': 'nl', 'note': '<p>Een soort <strong>b</strong>oom.</p>', 'markup': 'HTML'}
+        ],
+        'narrower': [],
+        'broader': [],
+        'related': [],
+        'member_of': ['3'],
+        'sources': [
+            {'citation': 'Monthy Python. Episode Three: How to recognise different types of trees from quite a long way away.'}
+        ]
+    }
+
+    chestnut = {
+        'id': '2',
+        'uri': 'http://id.trees.org/2',
+        'type': 'concept',
+        'labels': [
+            {'type': 'prefLabel', 'language': 'en', 'label': 'The Chestnut'},
+            {'type': 'altLabel', 'language': 'nl', 'label': 'De Paardekastanje'},
+            {'type': 'altLabel', 'language': 'fr', 'label': 'la châtaigne'},
+            {'type': 'sortLabel', 'language': 'nl', 'label': 'aaa'}
+        ],
+        'notes': [
+            {'type': 'definition', 'language': 'en', 'note': 'A different type of tree.'}
+        ],
+        'narrower': [],
+        'broader': [],
+        'related': [],
+        'member_of': ['3'],
+        'subordinate_arrays': [],
+        'sources': [
+            {
+                'citation': '<strong>Monthy Python.</strong> Episode Three: How to recognise different types of trees from quite a long way away.',
+                'markup': 'HTML'
+            }
+        ]
+    }
+
+    oak = {
+        'id': '4',
+        'uri': 'http://id.trees.org/4',
+        'type': 'concept',
+        'labels': [
+            {'type': 'prefLabel', 'language': 'en', 'label': 'The Oak'},
+            {'type': 'altLabel', 'language': 'nl', 'label': 'De Eik'},
+            {'type': 'altLabel', 'language': 'fr', 'label': 'le chêne'}
+        ],
+        'notes': [
+            {'type': 'definition', 'language': 'en', 'note': 'An even differenter type of tree.'}
+        ],
+        'narrower': [],
+        'broader': [],
+        'related': [],
+        'member_of': [],
+        'subordinate_arrays': [],
+        'matches': {
+            'exact': ['https://id.erfgoed.net/thesauri/soorten/297']
+        }
+    }
+
+    species = {
+        'id': 3,
+        'uri': 'http://id.trees.org/3',
+        'labels': [
+            {'type': 'prefLabel', 'language': 'en', 'label': 'Trees by species'},
+            {'type': 'prefLabel', 'language': 'nl', 'label': 'Bomen per soort'}
+        ],
+        'type': 'collection',
+        'members': ['1', '2', '4'],
+        'member_of': [],
+        'superordinates': []
+    }
+
+    return DictionaryProvider(
+        {'id': 'TREE', 'dataset': {'uri': 'https://id.trees.org/dataset'}},
+        [larch, chestnut, oak, species],
+        concept_scheme=ConceptScheme(
+            uri='http://id.trees.org',
+            labels=[
+                Label('Pythonic trees.', type='prefLabel', language='en'),
+                Label('Pythonische bomen.', type='prefLabel', language=None)
+            ],
+            notes=[
+                Note('<p>Trees as used by Monthy Python.</p>', type='definition', language='en', markup='HTML')
+            ]
+        )
+    )
+
+
+class TestRDFDumperMaterials:
+
+    def test_dump_dictionary_to_rdf(self, materials_provider):
+        graph_dump = utils.rdf_dumper(materials_provider)
+        lith_mat = URIRef('https://id.erfgoed.net/thesauri/materialen/42')
+        tienkwarts = URIRef('https://id.erfgoed.net/thesauri/materialen/44')
+        womkwarts = URIRef('https://id.erfgoed.net/thesauri/materialen/45')
+        assert (lith_mat, SKOS.narrower, tienkwarts) in graph_dump
+        assert (lith_mat, SKOS.narrower, womkwarts) in graph_dump
+        assert (womkwarts, SKOS.broader, lith_mat) in graph_dump
+        assert (tienkwarts, SKOS.broader, lith_mat) in graph_dump
+        assert not materials_provider.get_by_id(13).infer_concept_relations
+        koper = URIRef('https://id.erfgoed.net/thesauri/materialen/12')
+        legeringen = URIRef('https://id.erfgoed.net/thesauri/materialen/13')
+        brons = URIRef('https://id.erfgoed.net/thesauri/materialen/14')
+        messing = URIRef('https://id.erfgoed.net/thesauri/materialen/15')
+        assert (koper, SKOS_THES.subordinateArray, legeringen) in graph_dump
+        assert (legeringen, SKOS_THES.superOrdinate, koper) in graph_dump
+        assert (legeringen, SKOS.member, brons) in graph_dump
+        assert (legeringen, SKOS.member, messing) in graph_dump
+        assert (koper, SKOS.narrower, brons) not in graph_dump
+        assert (koper, SKOS.narrower, messing) not in graph_dump
+        xml = graph_dump.serialize(format='xml', encoding="UTF-8")
+        if isinstance(xml, bytes):
+            xml = xml.decode("UTF-8")
+        assert '<?xml' == xml[:5]
+        bont_skos_definition = '<skos:definition xml:lang="nl-BE">Bont is een gelooide dierlijke huid, dicht bezet met haren. Het wordt voornamelijk gebruikt voor het maken van kleding.</skos:definition>'
+        dcterms_id_skos_definition = '<dcterms:identifier rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">9</dcterms:identifier>'
+        assert bont_skos_definition in xml
+        assert dcterms_id_skos_definition in xml
+
+    def test_dump_collections_roundtrip(self, materials_provider, caplog):
+        caplog.set_level(logging.DEBUG)
+        graph_dump = utils.rdf_dumper(materials_provider)
+        provider = RDFProvider({'id': 'ImportMateriaal'}, graph_dump)
+        kwarts_mat = provider.get_by_id(43)
+        assert kwarts_mat.type == 'collection'
+        assert kwarts_mat.infer_concept_relations is True
+        legeringen = provider.get_by_id(13)
+        assert legeringen.type == 'collection'
+        assert legeringen.infer_concept_relations is False
+        bet_nr_vs = provider.get_by_id(68)
+        assert bet_nr_vs.type == 'collection'
+        assert bet_nr_vs.infer_concept_relations is True
+        assert set(provider.expand(68)) == {'39', '70'}
+
+    def test_dump_concept_with_superordinates(self, materials_provider, caplog):
+        caplog.set_level(logging.DEBUG)
+        graph_dump = utils.rdf_c_dumper(materials_provider, 44)
+
+        assert isinstance(graph_dump, Graph)
+        assert (
+            URIRef('https://id.erfgoed.net/thesauri/materialen/43'),
+            SKOS.member,
+            URIRef('https://id.erfgoed.net/thesauri/materialen/44')
+        ) in graph_dump
+        assert (
+            URIRef('https://id.erfgoed.net/thesauri/materialen/44'),
+            SKOS.broader,
+            URIRef('https://id.erfgoed.net/thesauri/materialen/42')
+        ) in graph_dump
+
+
+class TestRDFDumperProducts:
+
+    def test_dump_rdf_to_rdf(self, products_provider):
+        graph_dump = utils.rdf_dumper(products_provider)
+        xml = graph_dump.serialize(format='xml', encoding="UTF-8")
+        if isinstance(xml, bytes):
+            xml = xml.decode("UTF-8")
+        assert '<?xml' == xml[:5]
+
+        assert 'http://www.products.com/' in xml
+        assert 'http://www.products.com/Jewellery' in xml
+        assert 'http://www.products.com/Perfume' in xml
+        assert 'http://www.products.com/Product' in xml
+        assert 'http://www.products.com/Stuff' in xml
+
+    def test_dump_rdf_compare_type(self, products_provider):
+        graph_dump = utils.rdf_dumper(products_provider)
+        assert isinstance(graph_dump, Graph)
+
+    def test_dump_rdf_no_uri_as_local_identifier(self, products_provider, caplog):
+        caplog.set_level(logging.DEBUG)
+        graph_dump = utils.rdf_dumper(products_provider)
+
+        prod_uri = 'http://www.prodcuts.com/Product'
+        jewel_uri = 'http://www.products.com/Jewellery'
+        perfume_uri = 'http://www.products.com/Perfume'
+
+        prod = URIRef(prod_uri)
+        jewel = URIRef(jewel_uri)
+        perfume = URIRef(perfume_uri)
+
+        log.debug(graph_dump.serialize(format='turtle'))
+
+        assert (prod, DCTERMS.identifier, Literal(prod_uri)) not in graph_dump
+        assert (prod, DC.identifier, Literal(prod_uri)) not in graph_dump
+        assert (jewel, DCTERMS.identifier, Literal(jewel_uri)) not in graph_dump
+        assert (jewel, DC.identifier, Literal(jewel_uri)) not in graph_dump
+        assert (perfume, DCTERMS.identifier, Literal(perfume_uri)) not in graph_dump
+        assert (perfume, DC.identifier, Literal(perfume_uri)) not in graph_dump
+
+
+class TestRDFDumperTrees:
+
+    def test_dump_tree_to_rdf(self, tree_provider):
+        graph_dump = utils.rdf_dumper(tree_provider)
+        xml = graph_dump.serialize(format='xml', encoding="UTF-8")
+        if isinstance(xml, bytes):
+            xml = xml.decode("UTF-8")
+        assert '<?xml' == xml[:5]
+
+    def test_dump_larch_to_rdf(self, tree_provider):
+        graph_dump = utils.rdf_c_dumper(tree_provider, 1)
+        cs = URIRef('http://id.trees.org')
+        assert (cs, RDF.type, SKOS.ConceptScheme) in graph_dump
+        definitions = list(graph_dump.objects(cs, SKOS.definition))
+        assert any('Trees as used by Monthy Python.' in str(d) for d in definitions)
+        assert (cs, SKOS.prefLabel, Literal('Pythonic trees.', lang='en')) in graph_dump
+        xml = graph_dump.serialize(format='xml', encoding="UTF-8")
+        if isinstance(xml, bytes):
+            xml = xml.decode("UTF-8")
+        assert '<?xml' == xml[:5]
+
+    def test_dump_chestnut_to_rdf(self, tree_provider):
+        graph_dump = utils.rdf_c_dumper(tree_provider, 2)
+
+        chestnut = URIRef('http://id.trees.org/2')
+        assert (chestnut, SKOS.hiddenLabel, Literal('aaa', lang='nl')) in graph_dump
+        assert (chestnut, SKOS.altLabel, Literal('De Paardekastanje', lang='nl')) in graph_dump
+        assert (chestnut, SKOS.prefLabel, Literal('The Chestnut', lang='en')) in graph_dump
+        assert (chestnut, SKOS.altLabel, Literal('la châtaigne', lang='fr')) in graph_dump
+        assert (chestnut, SKOS.definition, Literal('A different type of tree.', lang='en')) in graph_dump
+
+        citations = list(graph_dump.objects(predicate=DCTERMS.bibliographicCitation))
+        assert citations[0] == Literal(
+            '<strong>Monthy Python.</strong> Episode Three: How to recognise different types of trees from quite a long way away.',
+            datatype=RDF.HTML
+        )
+
+    def test_dump_oak_to_rdf(self, tree_provider):
+        graph_dump = utils.rdf_c_dumper(tree_provider, 4)
+        oak = URIRef('http://id.trees.org/4')
+        eik = URIRef('https://id.erfgoed.net/thesauri/soorten/297')
+        assert (oak, SKOS.exactMatch, eik) in graph_dump
+
+    def test_dump_one_id_to_rdf_and_reload(self, tree_provider, caplog):
+        caplog.set_level(logging.DEBUG)
+        graph_dump1 = utils.rdf_c_dumper(tree_provider, 1)
+        provider = RDFProvider(
+            {'id': 'Number1', 'dataset': {'uri': 'http://id.trees.org/dataset'}},
+            graph_dump1
+        )
+        graph_dump2 = utils.rdf_c_dumper(provider, 1)
+        graph_full_dump2 = utils.rdf_dumper(provider)
+        assert provider.get_by_id(1)
+        assert provider.get_by_id(3)
+        assert len(graph_dump1) == len(graph_dump2)
+        assert len(graph_full_dump2) > len(graph_dump2)
+
+    def test_dump_conceptscheme_tree_to_rdf(self, tree_provider):
+        graph_dump = utils.rdf_conceptscheme_dumper(tree_provider)
+        cs = URIRef('http://id.trees.org')
+        assert (cs, RDF.type, SKOS.ConceptScheme) in graph_dump
+        definitions = list(graph_dump.objects(cs, SKOS.definition))
+        assert any('Trees as used by Monthy Python.' in str(d) for d in definitions)
+        assert (cs, SKOS.prefLabel, Literal('Pythonic trees.', lang='en')) in graph_dump
+
+
+class TestRDFDumperExtraData:
+
+    @pytest.fixture
+    def provider_with_notation(self):
+        from skosprovider.uri import UriPatternGenerator
+        larch = {
+            'id': '1',
+            'uri': 'http://id.trees.org/1',
+            'labels': [{'type': 'prefLabel', 'language': 'en', 'label': 'The Larch'}],
+            'notation': ['larch-001'],
+        }
+        chestnut = {
+            'id': '2',
+            'uri': 'http://id.trees.org/2',
+            'labels': [{'type': 'prefLabel', 'language': 'en', 'label': 'The Chestnut'}],
+        }
+        return DictionaryProvider(
+            {'id': 'TREES'},
+            [larch, chestnut],
+            uri_generator=UriPatternGenerator('http://id.trees.org/%s'),
+            concept_scheme=ConceptScheme('http://id.trees.org'),
+        )
+
+    @pytest.fixture
+    def notation_serializer(self):
+        def serializer(graph, subject, obj):
+            if isinstance(obj.extra_data, dict):
+                for notation in obj.extra_data.get('notation', []):
+                    graph.add((subject, SKOS.notation, Literal(notation)))
+        return serializer
+
+    def test_rdf_dumper_without_serializer_no_notation(self, provider_with_notation):
+        graph = utils.rdf_dumper(provider_with_notation)
+        larch = URIRef('http://id.trees.org/1')
+        assert (larch, SKOS.notation, Literal('larch-001')) not in graph
+
+    def test_rdf_dumper_with_serializer_adds_notation(self, provider_with_notation, notation_serializer):
+        graph = utils.rdf_dumper(provider_with_notation, extra_data_serializer=notation_serializer)
+        larch = URIRef('http://id.trees.org/1')
+        assert (larch, SKOS.notation, Literal('larch-001')) in graph
+
+    def test_rdf_dumper_serializer_only_called_for_extra_data(self, provider_with_notation, notation_serializer):
+        graph = utils.rdf_dumper(provider_with_notation, extra_data_serializer=notation_serializer)
+        chestnut = URIRef('http://id.trees.org/2')
+        assert list(graph.objects(chestnut, SKOS.notation)) == []
+
+    def test_rdf_c_dumper_with_serializer(self, provider_with_notation, notation_serializer):
+        graph = utils.rdf_c_dumper(provider_with_notation, '1', extra_data_serializer=notation_serializer)
+        larch = URIRef('http://id.trees.org/1')
+        assert (larch, SKOS.notation, Literal('larch-001')) in graph
+
+    def test_rdf_conceptscheme_dumper_with_serializer(self):
+        DCTERMS_CREATED = URIRef('http://purl.org/dc/terms/created')
+        cs = ConceptScheme('http://id.trees.org', extra_data={'created': '2024-01-01'})
+        provider = DictionaryProvider({'id': 'TREES'}, [], concept_scheme=cs)
+
+        def serializer(graph, subject, obj):
+            if isinstance(obj.extra_data, dict) and 'created' in obj.extra_data:
+                graph.add((subject, DCTERMS_CREATED, Literal(obj.extra_data['created'])))
+
+        graph = utils.rdf_conceptscheme_dumper(provider, extra_data_serializer=serializer)
+        cs_ref = URIRef('http://id.trees.org')
+        assert (cs_ref, DCTERMS_CREATED, Literal('2024-01-01')) in graph
+
+    def test_rdf_dumper_round_trip_extra_data(self, provider_with_notation, notation_serializer):
+        import rdflib
+        graph = utils.rdf_dumper(provider_with_notation, extra_data_serializer=notation_serializer)
+        rdf_provider = RDFProvider({'id': 'TREES'}, graph)
+        larch = rdf_provider.get_by_uri('http://id.trees.org/1')
+        assert isinstance(larch.extra_data, rdflib.Graph)
+        assert (URIRef('http://id.trees.org/1'), SKOS.notation, Literal('larch-001')) in larch.extra_data
+
+    def test_rdf_dumper_round_trip_no_extra_data(self, provider_with_notation, notation_serializer):
+        graph = utils.rdf_dumper(provider_with_notation, extra_data_serializer=notation_serializer)
+        rdf_provider = RDFProvider({'id': 'TREES'}, graph)
+        chestnut = rdf_provider.get_by_uri('http://id.trees.org/2')
+        assert chestnut.extra_data is None


### PR DESCRIPTION
Add skosprovider.rdf module with RDFLib-based provider and utilities. Includes examples, tests, test data, and documentation updates.

To keep the PRs manageable, I don't change too much yet of the original rdf skosprovider code.